### PR TITLE
Persist opencode plugin and state across container starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,7 @@
         "source=${localEnv:HOME}/.config/op,target=/home/igou/.config/op,type=bind,readonly",
         "source=${localEnv:HOME}/.config/cursor,target=/home/igou/.config/cursor,type=bind",
         "source=${localEnv:HOME}/.config/opencode,target=/home/igou/.config/opencode,type=bind",
+        "source=${localEnv:HOME}/.local/share/opencode,target=/home/igou/.local/share/opencode,type=bind",
         "source=${localEnv:HOME}/workspace,target=/workspace,type=bind",
         "source=/dev,target=/dev,type=bind"
     ],

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -4,7 +4,7 @@
 # (including CI runners) where these paths may not exist yet.
 set -euo pipefail
 
-for dir in "$HOME/.claude-container" "$HOME/.config/cursor" "$HOME/.config/opencode" "$HOME/.ssh" "$HOME/.kube" "$HOME/.config/argocd" "$HOME/.config/op" "$HOME/.terraform.d" "$HOME/workspace"; do
+for dir in "$HOME/.claude-container" "$HOME/.config/cursor" "$HOME/.config/opencode" "$HOME/.local/share/opencode" "$HOME/.ssh" "$HOME/.kube" "$HOME/.config/argocd" "$HOME/.config/op" "$HOME/.terraform.d" "$HOME/workspace"; do
     if [ ! -d "$dir" ]; then
         mkdir -p "$dir"
         echo "[init] Created $dir"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,10 @@ adr/                     # Architecture Decision Records
 bin/                     # Custom scripts (symlinked to ~/bin, on PATH)
 │   ├── claude-run       # Launch script for the Claude container
 │   ├── cursor-run       # Launch script for the Cursor agent container
-│   └── argocd-refresh-all
+│   ├── opencode-run     # Launch script for the opencode agent container
+│   ├── argocd-refresh-all
+│   ├── renovate-validate
+│   └── renovate-dry-run
 envs/                    # 1Password env files (op:// references only, no secrets) for use() function
 Makefile                 # Devcontainer lifecycle: build, up, down, shell, test, renovate targets
 tests/

--- a/bin/opencode-run
+++ b/bin/opencode-run
@@ -241,6 +241,15 @@ OPENCODE_STATE="${OPENCODE_STATE:-$HOME/.local/share/opencode}"
 mkdir -p "$OPENCODE_STATE"
 RUN_ARGS+=(-v "$OPENCODE_STATE:/home/igou/.local/share/opencode:Z")
 
+# opencode plugin/package cache — plugins declared in opencode.jsonc (e.g.
+# superpowers) are fetched from git into ~/.cache/opencode/packages/ on every
+# launch. Persisting it avoids refetching from GitHub each container start.
+# (Mount the subdir, not all of ~/.cache, since TMPDIR=/home/igou/.cache is
+# also used by Bun for native library extraction baked into the image.)
+OPENCODE_CACHE="${OPENCODE_CACHE:-$HOME/.cache/opencode}"
+mkdir -p "$OPENCODE_CACHE"
+RUN_ARGS+=(-v "$OPENCODE_CACHE:/home/igou/.cache/opencode:Z")
+
 for f in "${TMPFILES[@]}"; do
     RUN_ARGS+=(-v "$f:/tmp/kubeconfig:ro,Z")
 done


### PR DESCRIPTION
## Summary
- Bind-mount `~/.local/share/opencode` (plugin install dir) and `~/.cache/opencode` (plugin package cache) so plugins declared in `opencode.jsonc` survive container restarts.
- Mount the `opencode` subdir of `~/.cache` rather than all of `~/.cache` — TMPDIR is also `/home/igou/.cache`, which Bun uses for native library extraction baked into the image.
- Catches `CLAUDE.md` up to the current `bin/` tree (`opencode-run`, `renovate-validate`, `renovate-dry-run`).

## Test plan
- [ ] CI build passes
- [ ] After merge: `opencode-run`, install a plugin, exit container, relaunch — plugin persists without refetch