### PR TITLE
feat(mise): add Pipelines-as-Code CLI (tkn-pac)

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -37,6 +37,18 @@ url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-arm64.tar.gz"
 checksum = "blake3:2b86bd1c04526e242e4491e2d2889f7ef2312169b806d93e39114300d5385bfa"
 url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-x64.tar.gz"
 
+[[tools."aqua:tektoncd/pipelines-as-code"]]
+version = "0.46.0"
+backend = "aqua:tektoncd/pipelines-as-code"
+
+[tools."aqua:tektoncd/pipelines-as-code"."platforms.linux-arm64"]
+checksum = "sha256:c87c007c98034d11e249a1e780cb195ec3c90ba70e51c0fc92d8743b17d35f31"
+url = "https://github.com/tektoncd/pipelines-as-code/releases/download/v0.46.0/tkn-pac_0.46.0_linux_arm64.tar.gz"
+
+[tools."aqua:tektoncd/pipelines-as-code"."platforms.linux-x64"]
+checksum = "sha256:c5ed9e7ef329a33946f10c9c2692049d2dcbd8298edc2a02ece4de1e11a78b1b"
+url = "https://github.com/tektoncd/pipelines-as-code/releases/download/v0.46.0/tkn-pac_0.46.0_linux_x86_64.tar.gz"
+
 [[tools.argocd]]
 version = "3.3.9"
 backend = "aqua:argoproj/argo-cd"

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,9 @@ kubeconform = "0.7.0"
 kind = "0.31.0"
 act = "0.2.87"
 tekton-cli = "0.44.1"   # binary is `tkn`; mise registry key is tekton-cli
+# Pipelines-as-Code CLI (binary: tkn-pac). No short alias in mise's registry,
+# so use the explicit aqua: key form (same shape as aqua:nodejs/node below).
+"aqua:tektoncd/pipelines-as-code" = "0.46.0"
 rclone = "1.73.5"
 direnv = "2.37.1"
 age = "1.3.1"

--- a/tests/mise-expected-verification.toml
+++ b/tests/mise-expected-verification.toml
@@ -38,6 +38,7 @@ kubeconform = "sha256"
 kind = "sha256"
 act = "sha256"
 tekton-cli = "sha256"   # binary: tkn
+"aqua:tektoncd/pipelines-as-code" = "sha256"   # binary: tkn-pac
 rclone = "sha256"
 direnv = "sha256"
 age = "sha256"


### PR DESCRIPTION
## Summary

- Adds `tkn-pac` v0.46.0 (Pipelines-as-Code CLI — Tekton plugin for triggering pipelines from git events) to the mise-managed tool set.
- Verification floor: aqua-registry sha256 against upstream `checksums.txt` for both `linux-x64` and `linux-arm64`. No stronger provenance is published upstream (no cosign / SLSA / GPG / minisign blocks in [aqua-registry's package config](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/tektoncd/pipelines-as-code/registry.yaml)), so no postinstall hook is needed.
- v0.46.0 was released 2026-05-06, clearing the `minimum_release_age = "10d"` gate.

## Files touched

| File | Change |
|---|---|
| `mise.toml` | New `"aqua:tektoncd/pipelines-as-code" = "0.46.0"` entry next to `tekton-cli`. Explicit `aqua:` key form because mise's short registry has no alias for this package. |
| `mise.lock` | Auto-populated by `make mise-lock` — per-platform sha256 + URL for x64/arm64. |
| `tests/mise-expected-verification.toml` | `"aqua:tektoncd/pipelines-as-code" = "sha256"   # binary: tkn-pac` — the `# binary:` override makes the audit's launch check resolve `tkn-pac` instead of the registry key. |

## How this was produced

This is the first end-to-end exercise of the new `/adding-a-mise-tool` skill at `.claude/skills/adding-a-mise-tool/SKILL.md`. The skill's 7-step procedure produced the diff; running it surfaced one minor host-side wart (`tests/test-mise-lockfile.sh` trips on host-mise auto-discovering the repo's `mise.toml` from cwd — workaround: invoke from `/tmp`). The same script works under the CI/podman path it was designed for.

## Test plan

- [ ] CI green on `make test` (full devcontainer rebuild + `tests/test-mise.sh` audit confirms `aqua:tektoncd/pipelines-as-code` resolves to sha256 on both architectures, and `tkn-pac --version` launches inside the rebuilt image).
- [ ] CI green on `tests/test-mise-lockfile.sh` (lockfile-freshness check, runs via podman fallback in CI).
- [ ] Local `bash tests/test-mise-lockfile.sh` from `/tmp`: passed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)