### PR TITLE
fix(renovate): manage mise bootstrap as version-only, add SHA helper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -150,16 +150,18 @@ RUN rm -f /etc/pam.d/system-auth && \
 # Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
 # mise verifies all subsequent tools via aqua-registry's per-tool config
 # (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Manual SHA update on version bump:
-#   for a in x64 arm64; do curl -sL "https://github.com/jdx/mise/releases/download/<ver>/mise-<ver>-linux-${a}.tar.gz" | sha256sum; done
+# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
+# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
+#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
+# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.5.16"
-ARG MISE_SHA256_AMD64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
+ARG MISE_SHA256_X64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
 ARG MISE_SHA256_ARM64="00f94d934a957c67f083669003bc0fd9e6009aec5aa8c6f1649c376f115b3818"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_AMD64}" ;; \
+      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
       aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SSH_MOUNT = $(shell [ -S "$$SSH_AUTH_SOCK" ] && echo '--mount type=bind,source=$
 
 .DEFAULT_GOAL := help
 
-.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock
+.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock mise-bootstrap-sha
 
 
 ## Build the devcontainer image (with cache)
@@ -118,6 +118,22 @@ mise-lock:
 		[ -f mise.lock.bak ] && mv mise.lock.bak mise.lock; \
 		exit 1; \
 	fi
+
+## Print verified mise bootstrap SHA-256 digests for the pinned MISE_VERSION.
+## Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
+## run this after a bump and paste the output into the MISE_SHA256_* ARGs in all
+## three Dockerfiles. Values come from mise's published SHASUMS256.txt. See #67.
+mise-bootstrap-sha:
+	@ver=$$(grep -oP 'ARG MISE_VERSION="\K[^"]+' .devcontainer/Dockerfile); \
+	[ -n "$$ver" ] || { echo "could not read MISE_VERSION from .devcontainer/Dockerfile" >&2; exit 1; }; \
+	sums=$$(curl -fsSL "https://github.com/jdx/mise/releases/download/$$ver/SHASUMS256.txt") \
+		|| { echo "failed to fetch SHASUMS256.txt for $$ver" >&2; exit 1; }; \
+	x64=$$(printf '%s\n' "$$sums"   | awk -v n="mise-$$ver-linux-x64.tar.gz"   '$$2 ~ n"$$" {print $$1}'); \
+	arm64=$$(printf '%s\n' "$$sums" | awk -v n="mise-$$ver-linux-arm64.tar.gz" '$$2 ~ n"$$" {print $$1}'); \
+	[ -n "$$x64" ] && [ -n "$$arm64" ] || { echo "could not extract both SHAs from SHASUMS256.txt" >&2; exit 1; }; \
+	echo "# mise $$ver — verified against published SHASUMS256.txt"; \
+	echo "ARG MISE_SHA256_X64=\"$$x64\""; \
+	echo "ARG MISE_SHA256_ARM64=\"$$arm64\""
 
 ## Remove the devcontainer and clean up dangling images
 clean: down

--- a/builds/podman-rootful/Dockerfile
+++ b/builds/podman-rootful/Dockerfile
@@ -105,16 +105,18 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
 # Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
 # mise verifies all subsequent tools via aqua-registry's per-tool config
 # (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Manual SHA update on version bump:
-#   for a in x64 arm64; do curl -sL "https://github.com/jdx/mise/releases/download/<ver>/mise-<ver>-linux-${a}.tar.gz" | sha256sum; done
+# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
+# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
+#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
+# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.5.16"
-ARG MISE_SHA256_AMD64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
+ARG MISE_SHA256_X64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
 ARG MISE_SHA256_ARM64="00f94d934a957c67f083669003bc0fd9e6009aec5aa8c6f1649c376f115b3818"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_AMD64}" ;; \
+      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
       aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \

--- a/builds/podman-socket/Dockerfile
+++ b/builds/podman-socket/Dockerfile
@@ -103,16 +103,18 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
 # Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
 # mise verifies all subsequent tools via aqua-registry's per-tool config
 # (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Manual SHA update on version bump:
-#   for a in x64 arm64; do curl -sL "https://github.com/jdx/mise/releases/download/<ver>/mise-<ver>-linux-${a}.tar.gz" | sha256sum; done
+# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
+# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
+#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
+# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.5.16"
-ARG MISE_SHA256_AMD64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
+ARG MISE_SHA256_X64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
 ARG MISE_SHA256_ARM64="00f94d934a957c67f083669003bc0fd9e6009aec5aa8c6f1649c376f115b3818"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_AMD64}" ;; \
+      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
       aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \

--- a/renovate.json
+++ b/renovate.json
@@ -50,8 +50,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.sh$/", "/Dockerfile$/", "/Containerfile$/", "/mise\\.toml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\n(?:ARG )?\\w+_VERSION=\"(?<currentValue>[^\"]+)\"",
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\n(?:ARG )?\\w+_VERSION=\"(?<currentValue>[^\"]+)\"\\n(?:ARG )?\\w+_SHA256_AMD64=\"(?<currentDigest>[a-f0-9]+)\""
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\n(?:ARG )?\\w+_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "semver"
     }


### PR DESCRIPTION
## Summary

Fixes the broken Renovate management of the mise bootstrap pin (#67).

The `customManager`'s digest-capture matchString pulled `currentDigest` from `MISE_SHA256_AMD64` using `datasource=github-releases`, whose digest is the tag's **git commit SHA** (40-char SHA-1) — not the asset sha256. Every mise bump therefore produced an invalid x64 digest (`sha256sum -c` → "no properly formatted checksum lines"), and the regex never matched `_ARM64` so it went stale across versions. Surfaced in #58.

This adopts the model the repo already uses for **cursor-agent** and **opencode**: Renovate bumps the version only; SHAs are re-captured per bump. mise uniquely publishes a `SHASUMS256.txt`, so a helper makes the re-capture a one-liner.

## Changes

- **`renovate.json`** — drop the digest-capture matchString; the version-only matcher remains (verified: mise now matches with `currentValue` and no `currentDigest`).
- **Dockerfiles (×3)** — rename `MISE_SHA256_AMD64` → `MISE_SHA256_X64` for symmetry with the `_X64`/`_ARM64` convention; refresh the bump docs.
- **`Makefile`** — `make mise-bootstrap-sha`: fetches mise's published `SHASUMS256.txt` for the pinned `MISE_VERSION` and prints both verified ARG lines, ready to paste.

## Verification

```
$ make mise-bootstrap-sha
# mise v2026.5.16 — verified against published SHASUMS256.txt
ARG MISE_SHA256_X64="43c37041c8d5ba3fd1353c3244f2f346866b76f1bafb6c57f059678e1c7a4046"
ARG MISE_SHA256_ARM64="00f94d934a957c67f083669003bc0fd9e6009aec5aa8c6f1649c376f115b3818"
```

Matches the digests currently pinned on `main`. `make renovate-validate` passes. The CI build exercises the renamed `MISE_SHA256_X64` ARG end-to-end.

## Follow-up flow (documented in the Dockerfile)

Renovate opens a version-only mise PR → `make mise-bootstrap-sha` → paste the two ARG lines into all three Dockerfiles → green.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)