### PR TITLE
feat(devcontainer): verify mise bootstrap via GPG signature (drop pinned SHAs)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -147,31 +147,52 @@ RUN rm -f /etc/pam.d/system-auth && \
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
-# mise verifies all subsequent tools via aqua-registry's per-tool config
-# (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
-# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
-#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
-# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
+# Mise — declarative tool manager. The bootstrap binary is verified against
+# mise's GPG-signed release checksums; once installed, mise verifies all
+# subsequent tools via aqua-registry's per-tool config (cosign/SLSA/GPG/SHA256).
+# See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
+#
+# Trust anchor is the pinned key fingerprint below (rsa4096, expires 2028-01-02):
+# the key is fetched from mise's HTTPS endpoint at build time but rejected unless
+# its fingerprint matches AND the checksums carry a VALIDSIG from it. Renovate
+# bumps MISE_VERSION only — there is no per-version SHA to maintain.
+# Key UID (cross-checked at keys.openpgp.org and https://mise.jdx.dev/gpg-key.pub):
+# "mise releases <release@mise.jdx.dev>"
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.6.0"
-ARG MISE_SHA256_X64="a167298194e6d3f8eb52eccb9107cea36e9786b2b15a7d24b1386eb9f1bcd31c"
-ARG MISE_SHA256_ARM64="2dcf4aa7b02deeba2d042f2d4eda21b445b0dcc3005446db6700c2160ce0cf46"
+ARG MISE_GPG_FPR="24853EC9F655CE80B48E6C3A8B81C9D17413A06D"
+ARG MISE_GPG_URL="https://mise.jdx.dev/gpg-key.pub"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
-      aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
+      x86_64)  ARCH="x64" ;; \
+      aarch64) ARCH="arm64" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \
-    URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    TARBALL="mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    BASE="https://github.com/jdx/mise/releases/download/${MISE_VERSION}"; \
     WORK=$(mktemp -d); \
-    curl -fsSL -o "${WORK}/mise.tar.gz" "$URL"; \
-    echo "${EXPECTED_SHA}  ${WORK}/mise.tar.gz" | sha256sum -c -; \
-    tar -xz --strip-components=2 -C /usr/local/bin -f "${WORK}/mise.tar.gz" mise/bin/mise; \
+    export GNUPGHOME="$WORK/gnupg"; \
+    mkdir -p -m 0700 "$GNUPGHOME"; \
+    cd "$WORK"; \
+    curl -fsSL -o key.asc "${MISE_GPG_URL}"; \
+    gpg --batch --import key.asc; \
+    # Reject any key whose fingerprint doesn't match the pinned anchor.
+    gpg --list-keys --with-colons --with-fingerprint \
+      | awk -F: '$1=="fpr"{print $10}' \
+      | grep -qFx "${MISE_GPG_FPR}"; \
+    curl -fsSL -o "$TARBALL" "${BASE}/${TARBALL}"; \
+    curl -fsSL -o SHASUMS256.asc "${BASE}/SHASUMS256.asc"; \
+    # Require a good clearsigned-checksums signature from our pinned key.
+    gpg --batch --status-fd 1 --verify SHASUMS256.asc 2>/dev/null \
+      | grep -qF "VALIDSIG ${MISE_GPG_FPR}"; \
+    # Verify the tarball against its checksum from the signed list.
+    gpg --batch --decrypt SHASUMS256.asc 2>/dev/null \
+      | awk -v f="./${TARBALL}" '$2==f{print $1"  "f}' \
+      | sha256sum -c -; \
+    tar -xz --strip-components=2 -C /usr/local/bin -f "$TARBALL" mise/bin/mise; \
     chmod +x /usr/local/bin/mise; \
-    rm -rf "$WORK"; \
+    cd / && rm -rf "$WORK"; \
     mise --version
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/mise-autofix.yaml
+++ b/.github/workflows/mise-autofix.yaml
@@ -1,15 +1,15 @@
-name: mise autofix (Renovate)
+name: mise lockfile autofix (Renovate)
 
-# Hosted Renovate (the Mend GitHub App) cannot run postUpgradeTasks, so it
-# opens mise bumps that are structurally incomplete:
-#   - mise.toml version bumps without a regenerated mise.lock -> the locked
-#     `mise install` fails in the build ("<tool>@<ver> is not in the lockfile")
-#   - MISE_VERSION bumps without re-captured MISE_SHA256_* ARGs -> the
-#     Dockerfile's `sha256sum -c` fails on the new mise tarball
+# Hosted Renovate (the Mend GitHub App) cannot run postUpgradeTasks, so when it
+# bumps a tool version in mise.toml it does NOT regenerate mise.lock — the
+# locked `mise install` then fails in the build ("<tool>@<ver> is not in the
+# lockfile"). This workflow runs on Renovate PRs that touch mise.toml,
+# regenerates the lockfile with the same `make mise-lock` used locally, and
+# commits the result back to the PR branch.
 #
-# This workflow runs on Renovate PRs that touch those files, regenerates the
-# lockfile and re-captures the mise digests using the same `make` targets used
-# locally, then commits the result back to the PR branch.
+# The mise *binary* bump no longer needs help: the Dockerfiles verify it against
+# mise's GPG-signed checksums (pinned release-key fingerprint), so a version-only
+# MISE_VERSION bump is sufficient and needs no committed-back change.
 #
 # NOTE: a commit pushed with the default GITHUB_TOKEN does NOT trigger further
 # workflow runs, so the build check would never re-run on the fixed commit and
@@ -23,8 +23,6 @@ on:
     branches: [main]
     paths:
       - mise.toml
-      - .devcontainer/Dockerfile
-      - builds/**/Dockerfile
 
 permissions:
   contents: write
@@ -40,23 +38,19 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.MISE_AUTOFIX_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Regenerate mise.lock and re-capture mise digests
+      - name: Regenerate mise.lock
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          make mise-lock
-          make mise-bootstrap-sha-apply
+        run: make mise-lock
 
-      - name: Commit and push fixes (if any)
+      - name: Commit and push fix (if any)
         run: |
           if [ -z "$(git status --porcelain)" ]; then
-            echo "mise.lock and mise digests already in sync — nothing to fix."
+            echo "mise.lock already in sync — nothing to fix."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit \
-            -m "fix(mise): regenerate lockfile / re-capture mise digests" \
-            -m "Auto-generated: hosted Renovate cannot run postUpgradeTasks."
+          git commit -m "fix(mise): regenerate mise.lock for the bumped tool versions"
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ renovate.json            # Renovate config with custom regex manager for Dockerf
 |---|---|---|
 | Dockerfile (apt) | python3, podman, buildah, skopeo, jq, 1Password CLI, qemu-kvm, qemu-img, genisoimage, edk2-ovmf (virtualization), etc. | `.devcontainer/Dockerfile` |
 | Mise (mise.toml + mise.lock) | kubectl, helm, terraform, gh, argocd, kustomize, kubeseal, flux2, sops, kubeconform, kind, act, tkn, rclone, direnv, age, node, oc, virtctl, kube-burner, kube-burner-ocp | `mise.toml` (versions), `mise.lock` (per-asset SHA256) |
-| Dockerfile (binary downloads) | mise itself (TOFU SHA256), Cursor agent, opencode, Claude Code | `.devcontainer/Dockerfile` (ARG + RUN) |
+| Dockerfile (binary downloads) | mise itself (GPG-signed checksums), Cursor agent, opencode, Claude Code | `.devcontainer/Dockerfile` (ARG + RUN) |
 | pip (onCreateCommand) | Ansible ecosystem, yq, mkdocs-material | `.devcontainer/requirements.txt` |
 
 **Lifecycle hooks** (execution order):
@@ -98,10 +98,10 @@ Tools managed by mise (see Architecture table) are pinned in `mise.toml`
 with per-asset checksums in `mise.lock`. Renovate bumps the *version* in
 `mise.toml` but cannot regenerate `mise.lock` — the hosted Mend app cannot run
 postUpgradeTasks — so its raw PRs fail the locked `mise install`. The
-`.github/workflows/mise-autofix.yaml` workflow closes that gap: on Renovate
-PRs it runs `make mise-lock` (and re-captures the mise digests for
-`MISE_VERSION` bumps via `make mise-bootstrap-sha-apply`) and commits the
-result back. To bump manually:
+`.github/workflows/mise-autofix.yaml` workflow closes that gap: on Renovate PRs
+that touch `mise.toml` it runs `make mise-lock` and commits the result back.
+(The mise binary itself is verified against mise's GPG-signed checksums, so a
+version-only `MISE_VERSION` bump needs no follow-up.) To bump manually:
 
 ```bash
 # 1. Edit the version in mise.toml
@@ -141,5 +141,5 @@ shellcheck .devcontainer/post-create.sh .devcontainer/post-start.sh .devcontaine
 - **Environment switching via `op inject`**: `use <env>` resolves secrets via `op inject` and exports them in the current shell. `unuse <env>` removes them. Both are idempotent. No subshells. See [ADR-0001](adr/0001-environment-switching-with-1password.md).
 - **Claude Code native binary**: Installed via `curl https://claude.ai/install.sh` instead of the deprecated npm package, removing the Node.js dependency.
 - **No embedded file definitions**: Do not embed large file contents (heredocs, multi-line echo chains, inline Python scripts) inside shell scripts or Dockerfiles. Instead, extract them into standalone files under `dotfiles/` (for runtime config) or alongside the consuming script (for build-time assets like Python merge scripts), then `cp`/`cat`/`COPY` them into place. This keeps generated files lintable, diffable, and editable. Small one-liners and test fixtures are acceptable inline.
-- **Trust anchors**: Mise is bootstrapped via TOFU SHA256 (the only chicken-and-egg trust anchor for tool installs). Mise then verifies the 21 managed tools via aqua-registry's pinned cosign/SLSA/GPG/SHA256 config. Where aqua-registry's mise install path doesn't run the upstream signature step (helm, terraform, oc), `aqua-registry/<tool>-postinstall.sh` re-runs the GPG verification against a pinned-fingerprint key. The aqua-registry itself is pinned to a specific git SHA, Renovate-bumped, and the bump is gated by `tests/test-mise.sh` which asserts no verification method silently downgraded.
+- **Trust anchors**: The mise binary is bootstrapped by verifying its release tarball against mise's GPG-signed checksums (`SHASUMS256.asc`), anchored on the pinned release-key fingerprint `24853EC9F655CE80B48E6C3A8B81C9D17413A06D` (uid "mise releases <release@mise.jdx.dev>", fetched from `https://mise.jdx.dev/gpg-key.pub` but rejected unless fingerprint + VALIDSIG match) — that pinned fingerprint is the chicken-and-egg trust anchor for tool installs, and Renovate bumps `MISE_VERSION` only (no per-version SHA to maintain). Mise then verifies the 21 managed tools via aqua-registry's pinned cosign/SLSA/GPG/SHA256 config. Where aqua-registry's mise install path doesn't run the upstream signature step (helm, terraform, oc), `aqua-registry/<tool>-postinstall.sh` re-runs the GPG verification against a pinned-fingerprint key. The aqua-registry itself is pinned to a specific git SHA, Renovate-bumped, and the bump is gated by `tests/test-mise.sh` which asserts no verification method silently downgraded.
 - **QEMU available in-container**: `qemu-kvm`, `qemu-img`, `genisoimage`, `edk2-ovmf`, `libvirt-daemon`, `libvirt-client`, and `python3-libvirt` are baked into the image so the `qemu` provisioner from [`ansible-collection-molecule_provisioners`](https://github.com/david-igou/ansible-collection-molecule_provisioners) can launch both process-driver and libvirt-driver guests. Ansible Galaxy collections (e.g. `community.libvirt`) are not baked into the image — install per-project via `ansible-galaxy collection install` at runtime if needed. `/dev/kvm` is accessible via the existing `/dev` bind-mount + `--privileged` runArgs. `virtqemud` is started by `post-start.sh` on every container start (`auth_unix = "none"` because the container has no systemd/D-Bus/polkit; access control falls back to socket file permissions). Host-side prep (kernel module load, `/dev/kvm` permissions) is tracked in [`ansible-collection-devhost#33`](https://github.com/david-igou/ansible-collection-devhost/issues/33).

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SSH_MOUNT = $(shell [ -S "$$SSH_AUTH_SOCK" ] && echo '--mount type=bind,source=$
 
 .DEFAULT_GOAL := help
 
-.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock mise-bootstrap-sha mise-bootstrap-sha-apply
+.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock
 
 
 ## Build the devcontainer image (with cache)
@@ -120,40 +120,6 @@ mise-lock:
 		[ -f mise.lock.bak ] && mv mise.lock.bak mise.lock; \
 		exit 1; \
 	fi
-
-## Print verified mise bootstrap SHA-256 digests for the pinned MISE_VERSION.
-## Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
-## run this after a bump and paste the output into the MISE_SHA256_* ARGs in all
-## three Dockerfiles. Values come from mise's published SHASUMS256.txt. See #67.
-mise-bootstrap-sha:
-	@ver=$$(grep -oP 'ARG MISE_VERSION="\K[^"]+' .devcontainer/Dockerfile); \
-	[ -n "$$ver" ] || { echo "could not read MISE_VERSION from .devcontainer/Dockerfile" >&2; exit 1; }; \
-	sums=$$(curl -fsSL "https://github.com/jdx/mise/releases/download/$$ver/SHASUMS256.txt") \
-		|| { echo "failed to fetch SHASUMS256.txt for $$ver" >&2; exit 1; }; \
-	x64=$$(printf '%s\n' "$$sums"   | awk -v n="mise-$$ver-linux-x64.tar.gz"   '$$2 ~ n"$$" {print $$1}'); \
-	arm64=$$(printf '%s\n' "$$sums" | awk -v n="mise-$$ver-linux-arm64.tar.gz" '$$2 ~ n"$$" {print $$1}'); \
-	[ -n "$$x64" ] && [ -n "$$arm64" ] || { echo "could not extract both SHAs from SHASUMS256.txt" >&2; exit 1; }; \
-	echo "# mise $$ver — verified against published SHASUMS256.txt"; \
-	echo "ARG MISE_SHA256_X64=\"$$x64\""; \
-	echo "ARG MISE_SHA256_ARM64=\"$$arm64\""
-
-## Re-capture and apply the verified mise digests for the pinned MISE_VERSION
-## in place across all three Dockerfiles. Same source and extraction as
-## mise-bootstrap-sha, but rewrites the ARG lines instead of printing them.
-## Used by the mise-autofix CI workflow (hosted Renovate cannot run
-## postUpgradeTasks); safe to run by hand too.
-mise-bootstrap-sha-apply:
-	@ver=$$(grep -oP 'ARG MISE_VERSION="\K[^"]+' .devcontainer/Dockerfile); \
-	[ -n "$$ver" ] || { echo "could not read MISE_VERSION from .devcontainer/Dockerfile" >&2; exit 1; }; \
-	sums=$$(curl -fsSL "https://github.com/jdx/mise/releases/download/$$ver/SHASUMS256.txt") \
-		|| { echo "failed to fetch SHASUMS256.txt for $$ver" >&2; exit 1; }; \
-	x64=$$(printf '%s\n' "$$sums"   | awk -v n="mise-$$ver-linux-x64.tar.gz"   '$$2 ~ n"$$" {print $$1}'); \
-	arm64=$$(printf '%s\n' "$$sums" | awk -v n="mise-$$ver-linux-arm64.tar.gz" '$$2 ~ n"$$" {print $$1}'); \
-	[ -n "$$x64" ] && [ -n "$$arm64" ] || { echo "could not extract both SHAs from SHASUMS256.txt" >&2; exit 1; }; \
-	for f in .devcontainer/Dockerfile builds/podman-rootful/Dockerfile builds/podman-socket/Dockerfile; do \
-		sed -i -E "s|^(ARG MISE_SHA256_X64=).*|\1\"$$x64\"|; s|^(ARG MISE_SHA256_ARM64=).*|\1\"$$arm64\"|" "$$f"; \
-	done; \
-	echo "Applied mise $$ver digests (x64+arm64) to all three Dockerfiles."
 
 ## Remove the devcontainer and clean up dangling images
 clean: down

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mechanism. See [CLAUDE.md](CLAUDE.md) for the per-layer Renovate strategy.
 |---|---|---|
 | Dockerfile (dnf) | podman, buildah, skopeo, jq, direnv, gpg2, 1Password CLI, Docker CLI, base utilities | `.devcontainer/Dockerfile` |
 | Mise (`mise.toml` + `mise.lock`) | kubectl, helm, terraform, gh, argocd, kustomize, kubeseal, flux2, sops, kubeconform, kind, act, tkn, rclone, direnv, age, node, oc, virtctl, kube-burner, kube-burner-ocp | `mise.toml` (versions) + `mise.lock` (per-asset checksums) |
-| Dockerfile (binary downloads) | mise itself (TOFU SHA256 — trust anchor), Claude Code, Cursor agent, opencode | `.devcontainer/Dockerfile` (ARG + RUN) |
+| Dockerfile (binary downloads) | mise itself (GPG-signed checksums — trust anchor), Claude Code, Cursor agent, opencode | `.devcontainer/Dockerfile` (ARG + RUN) |
 | pip (onCreateCommand) | Ansible ecosystem, yq, mkdocs-material | `.devcontainer/requirements.txt` |
 
 **Verification floor for mise-managed tools** (asserted by
@@ -317,9 +317,9 @@ rootless networking. Docker CLI is also available via the host socket
 All tool versions are pinned and managed by [Renovate](https://docs.renovatebot.com/):
 
 - **Dockerfile base image** — pinned by digest, updated by Renovate's Docker manager
-- **Mise-managed CLI tools** (21 binaries) — pinned in `mise.toml`, per-asset checksums in `mise.lock`. Renovate's native `mise` manager bumps versions; `make mise-lock` (run by Renovate's `postUpgradeTasks`) refreshes the lockfile.
+- **Mise-managed CLI tools** (21 binaries) — pinned in `mise.toml`, per-asset checksums in `mise.lock`. Renovate's native `mise` manager bumps versions; the `mise-autofix` workflow runs `make mise-lock` to refresh the lockfile on those PRs (the hosted Mend app cannot run `postUpgradeTasks`).
 - **aqua-registry pin** — the upstream registry that mise consumes is pinned to a specific git SHA in `mise.toml`. Renovate bumps it; `tests/test-mise.sh` gates the bump by asserting no per-tool verification method silently downgraded.
-- **Mise itself** + Claude Code + Cursor agent + opencode — pinned in `.devcontainer/Dockerfile` ARG blocks with `# renovate:` comments and the `github-releases` datasource (custom regex manager). SHA256 (and PGP for Claude) verified at build time.
+- **Mise itself** + Claude Code + Cursor agent + opencode — pinned in `.devcontainer/Dockerfile` ARG blocks with `# renovate:` comments and the `github-releases` datasource (custom regex manager). Verified at build time: mise and Claude Code via pinned-fingerprint GPG signatures, Cursor agent and opencode via SHA256.
 - **Python packages** — pinned in `.devcontainer/requirements.txt`, updated by `pip_requirements` manager.
 
 Trust anchors (mise itself, aqua-registry pin) are routed into their own

--- a/builds/podman-rootful/Dockerfile
+++ b/builds/podman-rootful/Dockerfile
@@ -102,31 +102,52 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
-# mise verifies all subsequent tools via aqua-registry's per-tool config
-# (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
-# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
-#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
-# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
+# Mise — declarative tool manager. The bootstrap binary is verified against
+# mise's GPG-signed release checksums; once installed, mise verifies all
+# subsequent tools via aqua-registry's per-tool config (cosign/SLSA/GPG/SHA256).
+# See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
+#
+# Trust anchor is the pinned key fingerprint below (rsa4096, expires 2028-01-02):
+# the key is fetched from mise's HTTPS endpoint at build time but rejected unless
+# its fingerprint matches AND the checksums carry a VALIDSIG from it. Renovate
+# bumps MISE_VERSION only — there is no per-version SHA to maintain.
+# Key UID (cross-checked at keys.openpgp.org and https://mise.jdx.dev/gpg-key.pub):
+# "mise releases <release@mise.jdx.dev>"
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.6.0"
-ARG MISE_SHA256_X64="a167298194e6d3f8eb52eccb9107cea36e9786b2b15a7d24b1386eb9f1bcd31c"
-ARG MISE_SHA256_ARM64="2dcf4aa7b02deeba2d042f2d4eda21b445b0dcc3005446db6700c2160ce0cf46"
+ARG MISE_GPG_FPR="24853EC9F655CE80B48E6C3A8B81C9D17413A06D"
+ARG MISE_GPG_URL="https://mise.jdx.dev/gpg-key.pub"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
-      aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
+      x86_64)  ARCH="x64" ;; \
+      aarch64) ARCH="arm64" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \
-    URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    TARBALL="mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    BASE="https://github.com/jdx/mise/releases/download/${MISE_VERSION}"; \
     WORK=$(mktemp -d); \
-    curl -fsSL -o "${WORK}/mise.tar.gz" "$URL"; \
-    echo "${EXPECTED_SHA}  ${WORK}/mise.tar.gz" | sha256sum -c -; \
-    tar -xz --strip-components=2 -C /usr/local/bin -f "${WORK}/mise.tar.gz" mise/bin/mise; \
+    export GNUPGHOME="$WORK/gnupg"; \
+    mkdir -p -m 0700 "$GNUPGHOME"; \
+    cd "$WORK"; \
+    curl -fsSL -o key.asc "${MISE_GPG_URL}"; \
+    gpg --batch --import key.asc; \
+    # Reject any key whose fingerprint doesn't match the pinned anchor.
+    gpg --list-keys --with-colons --with-fingerprint \
+      | awk -F: '$1=="fpr"{print $10}' \
+      | grep -qFx "${MISE_GPG_FPR}"; \
+    curl -fsSL -o "$TARBALL" "${BASE}/${TARBALL}"; \
+    curl -fsSL -o SHASUMS256.asc "${BASE}/SHASUMS256.asc"; \
+    # Require a good clearsigned-checksums signature from our pinned key.
+    gpg --batch --status-fd 1 --verify SHASUMS256.asc 2>/dev/null \
+      | grep -qF "VALIDSIG ${MISE_GPG_FPR}"; \
+    # Verify the tarball against its checksum from the signed list.
+    gpg --batch --decrypt SHASUMS256.asc 2>/dev/null \
+      | awk -v f="./${TARBALL}" '$2==f{print $1"  "f}' \
+      | sha256sum -c -; \
+    tar -xz --strip-components=2 -C /usr/local/bin -f "$TARBALL" mise/bin/mise; \
     chmod +x /usr/local/bin/mise; \
-    rm -rf "$WORK"; \
+    cd / && rm -rf "$WORK"; \
     mise --version
 
 # ---------------------------------------------------------------------------

--- a/builds/podman-socket/Dockerfile
+++ b/builds/podman-socket/Dockerfile
@@ -100,31 +100,52 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Mise — declarative tool manager. Bootstrap via TOFU SHA256; once installed,
-# mise verifies all subsequent tools via aqua-registry's per-tool config
-# (cosign/SLSA/GPG/SHA256). See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
-# Renovate bumps MISE_VERSION only (version-only, like cursor-agent/opencode);
-# the SHAs must be re-captured on each bump. mise publishes a SHASUMS256.txt, so:
-#   make mise-bootstrap-sha   # prints verified MISE_SHA256_X64 + _ARM64 for the pinned version
-# (or by hand: curl -sL https://github.com/jdx/mise/releases/download/<ver>/SHASUMS256.txt)
+# Mise — declarative tool manager. The bootstrap binary is verified against
+# mise's GPG-signed release checksums; once installed, mise verifies all
+# subsequent tools via aqua-registry's per-tool config (cosign/SLSA/GPG/SHA256).
+# See docs/superpowers/specs/2026-05-16-mise-tool-management-design.md
+#
+# Trust anchor is the pinned key fingerprint below (rsa4096, expires 2028-01-02):
+# the key is fetched from mise's HTTPS endpoint at build time but rejected unless
+# its fingerprint matches AND the checksums carry a VALIDSIG from it. Renovate
+# bumps MISE_VERSION only — there is no per-version SHA to maintain.
+# Key UID (cross-checked at keys.openpgp.org and https://mise.jdx.dev/gpg-key.pub):
+# "mise releases <release@mise.jdx.dev>"
 # renovate: datasource=github-releases depName=jdx/mise
 ARG MISE_VERSION="v2026.6.0"
-ARG MISE_SHA256_X64="a167298194e6d3f8eb52eccb9107cea36e9786b2b15a7d24b1386eb9f1bcd31c"
-ARG MISE_SHA256_ARM64="2dcf4aa7b02deeba2d042f2d4eda21b445b0dcc3005446db6700c2160ce0cf46"
+ARG MISE_GPG_FPR="24853EC9F655CE80B48E6C3A8B81C9D17413A06D"
+ARG MISE_GPG_URL="https://mise.jdx.dev/gpg-key.pub"
 RUN set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
-      x86_64)  ARCH="x64";   EXPECTED_SHA="${MISE_SHA256_X64}" ;; \
-      aarch64) ARCH="arm64"; EXPECTED_SHA="${MISE_SHA256_ARM64}" ;; \
+      x86_64)  ARCH="x64" ;; \
+      aarch64) ARCH="arm64" ;; \
       *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;; \
     esac; \
-    URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    TARBALL="mise-${MISE_VERSION}-linux-${ARCH}.tar.gz"; \
+    BASE="https://github.com/jdx/mise/releases/download/${MISE_VERSION}"; \
     WORK=$(mktemp -d); \
-    curl -fsSL -o "${WORK}/mise.tar.gz" "$URL"; \
-    echo "${EXPECTED_SHA}  ${WORK}/mise.tar.gz" | sha256sum -c -; \
-    tar -xz --strip-components=2 -C /usr/local/bin -f "${WORK}/mise.tar.gz" mise/bin/mise; \
+    export GNUPGHOME="$WORK/gnupg"; \
+    mkdir -p -m 0700 "$GNUPGHOME"; \
+    cd "$WORK"; \
+    curl -fsSL -o key.asc "${MISE_GPG_URL}"; \
+    gpg --batch --import key.asc; \
+    # Reject any key whose fingerprint doesn't match the pinned anchor.
+    gpg --list-keys --with-colons --with-fingerprint \
+      | awk -F: '$1=="fpr"{print $10}' \
+      | grep -qFx "${MISE_GPG_FPR}"; \
+    curl -fsSL -o "$TARBALL" "${BASE}/${TARBALL}"; \
+    curl -fsSL -o SHASUMS256.asc "${BASE}/SHASUMS256.asc"; \
+    # Require a good clearsigned-checksums signature from our pinned key.
+    gpg --batch --status-fd 1 --verify SHASUMS256.asc 2>/dev/null \
+      | grep -qF "VALIDSIG ${MISE_GPG_FPR}"; \
+    # Verify the tarball against its checksum from the signed list.
+    gpg --batch --decrypt SHASUMS256.asc 2>/dev/null \
+      | awk -v f="./${TARBALL}" '$2==f{print $1"  "f}' \
+      | sha256sum -c -; \
+    tar -xz --strip-components=2 -C /usr/local/bin -f "$TARBALL" mise/bin/mise; \
     chmod +x /usr/local/bin/mise; \
-    rm -rf "$WORK"; \
+    cd / && rm -rf "$WORK"; \
     mise --version
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The mise binary was bootstrapped via per-version `MISE_SHA256_X64/ARM64` ARGs in all three Dockerfiles. Hosted Renovate bumps `MISE_VERSION` **only** (version-only regex manager), so every bump shipped stale SHAs and failed the build's `sha256sum -c` (that was #72) until a follow-up commit re-captured them.

This implements approach **1a** from our discussion: make the per-version SHA unnecessary by verifying the bootstrap binary against mise's **GPG-signed release checksums**, so a version-only bump is self-contained. No automated write-back is involved for the binary.

## How

Mirrors the repo's existing GPG-pin idiom (Claude Code install block; `helm`/`oc`/`terraform` postinstall):

1. Fetch mise's public key from `https://mise.jdx.dev/gpg-key.pub` into a fresh `GNUPGHOME`.
2. **Reject** unless the imported key's fingerprint matches the pinned anchor `24853EC9F655CE80B48E6C3A8B81C9D17413A06D`.
3. `gpg --status-fd 1 --verify SHASUMS256.asc` and require a `VALIDSIG <fpr>` from that exact key.
4. Extract the tarball's checksum from the **verified** signed list and `sha256sum -c`.

Trust anchor is now the pinned **key fingerprint** (rsa4096, exp 2028-01-02, uid `mise releases <release@mise.jdx.dev>`) — stable across versions — instead of a per-version hash. Fingerprint cross-checked three ways: the signature itself, keys.openpgp.org, and mise's own domain.

## Scope

- **3 Dockerfiles** (`.devcontainer`, `builds/podman-rootful`, `builds/podman-socket`): GPG-verify bootstrap; drop `MISE_SHA256_*` ARGs.
- **Makefile**: remove the now-obsolete `mise-bootstrap-sha` / `mise-bootstrap-sha-apply` targets.
- **mise-autofix.yaml**: drop the SHA step — it now only regenerates `mise.lock` (the #70 class) and triggers on `mise.toml` changes. *(The lockfile autofix still commits back; eliminating that auto-write is a separate decision — approaches 3/4.)*
- **CLAUDE.md / README.md**: document the GPG trust anchor; fix stale `postUpgradeTasks` claims.

## Verification

Ran the exact new sequence against v2026.6.0 in isolation (no devcontainer rebuild): good signature → checksum match → extract → `mise --version` = `2026.6.0`. **Negative test**: a tampered tarball is correctly rejected. No test references the removed ARGs (`test-pinned-versions.sh` covers Claude/Cursor/opencode; `test-mise.sh` checks `MISE_VERSION`, still present).

> Note: `docs/superpowers/specs|plans/2026-05-16-*` still describe the original TOFU-SHA bootstrap; left as dated historical design records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)