### PR TITLE
feat(ci): weekly CalVer release pipeline

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   prepare:
@@ -32,9 +33,9 @@ jobs:
       - name: File an issue on failure
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue create --repo igou-io/igou-devenv \
-            --title "Weekly mise lock prepare failed ($(date -u +%Y-%m-%d))" \
+            --title "Weekly mise lock prepare failed ($(date -u +%Y.%m.%d))" \
             --body "release-prepare could not regenerate/merge the mise PR. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Fix manually: \`make mise-lock\` on the renovate/mise-managed-cli-tools branch and push." \
-            || true
+            || echo "::warning::failed to file tracking issue"

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,40 @@
+name: release-prepare (weekly mise lock)
+
+# Monday 06:30 UTC (after Renovate's Sunday run). Renovate cannot regenerate
+# mise.lock (hosted Mend app, no postUpgradeTasks), so its mise-tools PR is
+# stale. This job regenerates the lock, pushes it (which re-triggers CI), waits
+# for green, and merges — using RELEASE_PAT so the push actually re-triggers
+# workflows (a GITHUB_TOKEN push would not). The 08:00 release.yaml then ships.
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Lock and merge the open mise PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash bin/release-prepare-mise
+
+      - name: File an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh issue create --repo igou-io/igou-devenv \
+            --title "Weekly mise lock prepare failed ($(date -u +%Y-%m-%d))" \
+            --body "release-prepare could not regenerate/merge the mise PR. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Fix manually: \`make mise-lock\` on the renovate/mise-managed-cli-tools branch and push." \
+            || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,86 @@
+name: release (weekly CalVer)
+
+# Monday 08:00 UTC. Snapshots whatever is on main (the week's merged Renovate
+# updates + the mise PR merged by release-prepare) into a dated release:
+# image :YYYY.MM.DD + :latest, git tag vYYYY.MM.DD, and a GitHub Release with
+# auto-generated notes + the SBOM. Idempotent; skips weeks with no changes.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + test only; do not tag/publish/release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide version and whether to release
+        id: plan
+        run: |
+          VERSION="$(date -u +%Y.%m.%d)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists — skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          last="$(git tag --list 'v*' --sort=-creatordate | head -1)"
+          if [ -n "$last" ] && [ -z "$(git log "$last"..HEAD --oneline)" ]; then
+            echo "main has not advanced since $last — skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: steps.plan.outputs.proceed == 'true'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and test devcontainer
+        if: steps.plan.outputs.proceed == 'true'
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          push: ${{ inputs.dry_run && 'never' || 'always' }}
+          imageName: ghcr.io/igou-io/igou-devenv
+          runCmd: /workspace/igou-devenv/tests/run-all.sh
+
+      - name: Tag and push the CalVer image
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        run: |
+          docker tag  ghcr.io/igou-io/igou-devenv:latest ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          docker push ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+
+      - name: Generate SBOM
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          artifact-name: devcontainer-sbom-${{ steps.plan.outputs.version }}
+          output-file: devcontainer.spdx.json
+          format: spdx-json
+
+      - name: Tag and create GitHub Release
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ steps.plan.outputs.version }}"
+          git push origin "v${{ steps.plan.outputs.version }}"
+          gh release create "v${{ steps.plan.outputs.version }}" \
+            --repo igou-io/igou-devenv \
+            --title "v${{ steps.plan.outputs.version }}" \
+            --generate-notes \
+            devcontainer.spdx.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ name: release (weekly CalVer)
 # updates + the mise PR merged by release-prepare) into a dated release:
 # image :YYYY.MM.DD + :latest, git tag vYYYY.MM.DD, and a GitHub Release with
 # auto-generated notes + the SBOM. Idempotent; skips weeks with no changes.
+#
+# Also manually runnable from the Actions tab / `gh workflow run release.yaml`
+# with inputs below — handy for testing the pipeline on demand.
 
 on:
   schedule:
@@ -12,6 +15,14 @@ on:
     inputs:
       dry_run:
         description: "Build + test only; do not tag/publish/release"
+        type: boolean
+        default: false
+      version:
+        description: "Version/tag override (default: today UTC YYYY.MM.DD). Use a unique value for repeat test releases, e.g. 0.0.0-test."
+        type: string
+        default: ""
+      force:
+        description: "Release even if the tag exists or main hasn't advanced (for manual test runs)"
         type: boolean
         default: false
 
@@ -30,10 +41,15 @@ jobs:
       - name: Decide version and whether to release
         id: plan
         run: |
-          VERSION="$(date -u +%Y.%m.%d)"
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then VERSION="$(date -u +%Y.%m.%d)"; fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "force=true — releasing v$VERSION regardless of guards."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists — skipping."
+            echo "Tag v$VERSION already exists — skipping (use force + a unique version to re-release)."
             echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           last="$(git tag --list 'v*' --sort=-creatordate | head -1)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Tag and push the CalVer image
         if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
         run: |
+          # devcontainers/ci (push: always) also --loads :latest into the local
+          # docker daemon; we retag that exact image so the CalVer tag == what was tested.
           docker tag  ghcr.io/igou-io/igou-devenv:latest ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
           docker push ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
 
@@ -77,7 +79,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag "v${{ steps.plan.outputs.version }}"
+          git tag -a "v${{ steps.plan.outputs.version }}" -m "v${{ steps.plan.outputs.version }}"
           git push origin "v${{ steps.plan.outputs.version }}"
           gh release create "v${{ steps.plan.outputs.version }}" \
             --repo igou-io/igou-devenv \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ tests/
 renovate.json            # Renovate config with custom regex manager for Dockerfile ARGs
 .github/workflows/build.yaml         # CI: builds full devcontainer on push/PR via devcontainers/ci
 .github/workflows/mise-lockfile-check.yaml  # CI: fails PRs whose mise.lock is stale vs mise.toml
+.github/workflows/release-prepare.yaml  # CI: Mon 06:30 — regenerate mise.lock + merge the mise PR
+.github/workflows/release.yaml          # CI: Mon 08:00 — weekly CalVer image + git tag + GitHub Release
 ```
 
 **Tool installation layers:**
@@ -117,6 +119,25 @@ If the verification audit (`tests/test-mise.sh`) flags a downgrade
 (e.g., aqua-registry switched argocd from SLSA to SHA-only), update
 `tests/mise-expected-verification.toml` to match — but only after
 confirming the upstream change was deliberate.
+
+### Weekly release (CalVer)
+
+Every Monday two scheduled workflows run:
+
+1. `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` on the open
+   Renovate mise PR (`bin/release-prepare-mise`), waits for green, and merges
+   it — using `RELEASE_PAT`. If the bump breaks the build it files an issue and
+   leaves the PR open; the release still ships the rest.
+2. `release.yaml` (08:00 UTC) builds + tests `main`, publishes
+   `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` + `:latest`, pushes tag
+   `vYYYY.MM.DD`, and creates a GitHub Release (auto notes + SBOM). Skips weeks
+   with no changes; idempotent.
+
+Manual fallback: if `release-prepare` files an issue, regenerate the lock by
+hand — `make mise-lock` on the `renovate/mise-managed-cli-tools` branch, then
+push; it merges and rides the next weekly release.
+
+Requires the `RELEASE_PAT` repo secret (Contents + Pull-requests: read/write).
 
 ## Pre-push Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,14 @@ Manual fallback: if `release-prepare` files an issue, regenerate the lock by
 hand — `make mise-lock` on the `renovate/mise-managed-cli-tools` branch, then
 push; it merges and rides the next weekly release.
 
+Manual / test release: `release.yaml` is also `workflow_dispatch`-able (Actions
+tab or `gh workflow run release.yaml`):
+- `-f dry_run=true` — build + test only, no publish (safe, repeatable).
+- `-f version=0.0.0-test -f force=true` — cut a throwaway release on demand
+  (unique `version` avoids clashing with the real weekly CalVer tags; `force`
+  bypasses the "tag exists / main not advanced" skip guards). Delete the test
+  tag/release/image afterward.
+
 Requires the `RELEASE_PAT` repo secret (Contents + Pull-requests: read/write).
 
 ## Pre-push Requirements

--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ A Monday pipeline cuts a dated release of the devcontainer:
 `:latest` always tracks `main`; the `:YYYY.MM.DD` tags are immutable weekly
 snapshots to pin or roll back to. Needs the `RELEASE_PAT` secret.
 
+`release.yaml` can also be run on demand (`gh workflow run release.yaml`):
+`-f dry_run=true` for build+test only, or `-f version=0.0.0-test -f force=true`
+to cut a throwaway test release.
+
 ## CI
 
 GitHub Actions builds the devcontainer on every push and PR to `main` using

--- a/README.md
+++ b/README.md
@@ -332,6 +332,19 @@ make renovate-validate                     # validate config syntax
 GITHUB_TOKEN=ghp_... make renovate-dry-run # see what would be updated
 ```
 
+### Weekly release
+
+A Monday pipeline cuts a dated release of the devcontainer:
+
+- `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` to merge the week's
+  Renovate mise PR (it can't merge itself — the hosted app can't regenerate the
+  lock).
+- `release.yaml` (08:00 UTC) publishes `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` +
+  `:latest`, tags `vYYYY.MM.DD`, and creates a GitHub Release with notes + SBOM.
+
+`:latest` always tracks `main`; the `:YYYY.MM.DD` tags are immutable weekly
+snapshots to pin or roll back to. Needs the `RELEASE_PAT` secret.
+
 ## CI
 
 GitHub Actions builds the devcontainer on every push and PR to `main` using

--- a/bin/release-prepare-mise
+++ b/bin/release-prepare-mise
@@ -30,10 +30,11 @@ else
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   git commit -am "chore(mise): regenerate mise.lock"
   git push
-  # Give GitHub a moment to register the new checks before watching.
-  sleep 30
 fi
 
+# Let any freshly-pushed (or freshly-opened-PR) checks register before watching,
+# so `gh pr checks --watch` doesn't exit early on a transient "no checks yet".
+sleep 30
 echo "Waiting for checks on PR #$pr to complete..."
 gh pr checks "$pr" --repo "$REPO" --watch --interval 30
 

--- a/bin/release-prepare-mise
+++ b/bin/release-prepare-mise
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Finish the open Renovate mise-tools PR so it can merge: regenerate mise.lock,
+# push it (a PAT push re-triggers CI), wait for the build to pass, then
+# squash-merge. Hosted Renovate cannot regenerate the lock itself.
+#
+# Requires (set by the workflow):
+#   GH_TOKEN      a token that re-triggers workflows (RELEASE_PAT) — used by gh + git
+#   GITHUB_TOKEN  default token — used by `make mise-lock` for GitHub API rate limits
+# Also requires: podman, make, gh, git.
+set -euo pipefail
+
+REPO="igou-io/igou-devenv"
+BRANCH="renovate/mise-managed-cli-tools"
+
+pr="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+if [ -z "$pr" ]; then
+  echo "No open mise PR ($BRANCH) — nothing to prepare."
+  exit 0
+fi
+echo "Preparing mise PR #$pr"
+
+gh pr checkout "$pr" --repo "$REPO"
+
+make mise-lock
+
+if git diff --quiet -- mise.lock; then
+  echo "mise.lock already in sync; no commit needed."
+else
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git commit -am "chore(mise): regenerate mise.lock"
+  git push
+  # Give GitHub a moment to register the new checks before watching.
+  sleep 30
+fi
+
+echo "Waiting for checks on PR #$pr to complete..."
+gh pr checks "$pr" --repo "$REPO" --watch --interval 30
+
+gh pr merge "$pr" --repo "$REPO" --squash --delete-branch
+echo "Merged mise PR #$pr"

--- a/docs/superpowers/plans/2026-06-14-weekly-calver-release.md
+++ b/docs/superpowers/plans/2026-06-14-weekly-calver-release.md
@@ -1,0 +1,420 @@
+# Weekly CalVer Release Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a weekly Monday pipeline that regenerates the mise lockfile to merge Renovate's mise PR, then cuts a dated CalVer release (image + git tag + GitHub Release).
+
+**Architecture:** Hybrid — hosted Renovate keeps proposing mise versions (min-age 10d). A `release-prepare` workflow (Mon 06:30 UTC) locks + merges the mise PR using `RELEASE_PAT`; a `release` workflow (Mon 08:00 UTC) builds, publishes `:YYYY.MM.DD` + `:latest`, tags `vYYYY.MM.DD`, and creates a GitHub Release. Non-mise logic is extracted into `bin/release-prepare-mise` per the repo's no-embedded-scripts rule.
+
+**Tech Stack:** GitHub Actions, bash, `gh` CLI, `make mise-lock` (podman + `ghcr.io/jdx/mise`), `devcontainers/ci`, `anchore/sbom-action`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md`
+
+**Prerequisite (already provisioned):** `RELEASE_PAT` secret — fine-grained PAT on `igou-io/igou-devenv` with Contents: read/write + Pull requests: read/write.
+
+**Branch:** `feat/weekly-calver-release` (worktree at `/workspace/_wt/wtcalver`).
+
+---
+
+### Task 1: `bin/release-prepare-mise` script
+
+**Files:**
+- Create: `bin/release-prepare-mise`
+
+- [ ] **Step 1: Write the script**
+
+Create `bin/release-prepare-mise`:
+
+```bash
+#!/usr/bin/env bash
+# Finish the open Renovate mise-tools PR so it can merge: regenerate mise.lock,
+# push it (a PAT push re-triggers CI), wait for the build to pass, then
+# squash-merge. Hosted Renovate cannot regenerate the lock itself.
+#
+# Requires (set by the workflow):
+#   GH_TOKEN      a token that re-triggers workflows (RELEASE_PAT) — used by gh + git
+#   GITHUB_TOKEN  default token — used by `make mise-lock` for GitHub API rate limits
+# Also requires: podman, make, gh, git.
+set -euo pipefail
+
+REPO="igou-io/igou-devenv"
+BRANCH="renovate/mise-managed-cli-tools"
+
+pr="$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+if [ -z "$pr" ]; then
+  echo "No open mise PR ($BRANCH) — nothing to prepare."
+  exit 0
+fi
+echo "Preparing mise PR #$pr"
+
+gh pr checkout "$pr" --repo "$REPO"
+
+make mise-lock
+
+if git diff --quiet -- mise.lock; then
+  echo "mise.lock already in sync; no commit needed."
+else
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git commit -am "chore(mise): regenerate mise.lock"
+  git push
+  # Give GitHub a moment to register the new checks before watching.
+  sleep 30
+fi
+
+echo "Waiting for checks on PR #$pr to complete..."
+gh pr checks "$pr" --repo "$REPO" --watch --interval 30
+
+gh pr merge "$pr" --repo "$REPO" --squash --delete-branch
+echo "Merged mise PR #$pr"
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x bin/release-prepare-mise`
+
+- [ ] **Step 3: Lint with shellcheck (verify it passes)**
+
+Run: `shellcheck bin/release-prepare-mise`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Syntax-check the script parses**
+
+Run: `bash -n bin/release-prepare-mise`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/release-prepare-mise
+git commit -m "feat(ci): bin/release-prepare-mise — lock + merge the weekly mise PR"
+```
+
+---
+
+### Task 2: `release-prepare.yaml` workflow
+
+**Files:**
+- Create: `.github/workflows/release-prepare.yaml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/release-prepare.yaml`:
+
+```yaml
+name: release-prepare (weekly mise lock)
+
+# Monday 06:30 UTC (after Renovate's Sunday run). Renovate cannot regenerate
+# mise.lock (hosted Mend app, no postUpgradeTasks), so its mise-tools PR is
+# stale. This job regenerates the lock, pushes it (which re-triggers CI), waits
+# for green, and merges — using RELEASE_PAT so the push actually re-triggers
+# workflows (a GITHUB_TOKEN push would not). The 08:00 release.yaml then ships.
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Lock and merge the open mise PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash bin/release-prepare-mise
+
+      - name: File an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh issue create --repo igou-io/igou-devenv \
+            --title "Weekly mise lock prepare failed ($(date -u +%Y-%m-%d))" \
+            --body "release-prepare could not regenerate/merge the mise PR. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Fix manually: \`make mise-lock\` on the renovate/mise-managed-cli-tools branch and push." \
+            || true
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run:
+```bash
+python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/release-prepare.yaml')); print('jobs:', list(d['jobs']))"
+```
+Expected: `jobs: ['prepare']`
+
+- [ ] **Step 3: Lint with actionlint if available (optional)**
+
+Run: `command -v actionlint >/dev/null && actionlint .github/workflows/release-prepare.yaml || echo "actionlint not installed; skipping"`
+Expected: no errors (or skip message).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release-prepare.yaml
+git commit -m "feat(ci): release-prepare workflow (Mon 06:30 — lock+merge mise PR)"
+```
+
+---
+
+### Task 3: `release.yaml` workflow
+
+**Files:**
+- Create: `.github/workflows/release.yaml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/release.yaml`:
+
+```yaml
+name: release (weekly CalVer)
+
+# Monday 08:00 UTC. Snapshots whatever is on main (the week's merged Renovate
+# updates + the mise PR merged by release-prepare) into a dated release:
+# image :YYYY.MM.DD + :latest, git tag vYYYY.MM.DD, and a GitHub Release with
+# auto-generated notes + the SBOM. Idempotent; skips weeks with no changes.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + test only; do not tag/publish/release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide version and whether to release
+        id: plan
+        run: |
+          VERSION="$(date -u +%Y.%m.%d)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists — skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          last="$(git tag --list 'v*' --sort=-creatordate | head -1)"
+          if [ -n "$last" ] && [ -z "$(git log "$last"..HEAD --oneline)" ]; then
+            echo "main has not advanced since $last — skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: steps.plan.outputs.proceed == 'true'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and test devcontainer
+        if: steps.plan.outputs.proceed == 'true'
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          push: ${{ inputs.dry_run && 'never' || 'always' }}
+          imageName: ghcr.io/igou-io/igou-devenv
+          runCmd: /workspace/igou-devenv/tests/run-all.sh
+
+      - name: Tag and push the CalVer image
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        run: |
+          docker tag  ghcr.io/igou-io/igou-devenv:latest ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          docker push ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+
+      - name: Generate SBOM
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          artifact-name: devcontainer-sbom-${{ steps.plan.outputs.version }}
+          output-file: devcontainer.spdx.json
+          format: spdx-json
+
+      - name: Tag and create GitHub Release
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ steps.plan.outputs.version }}"
+          git push origin "v${{ steps.plan.outputs.version }}"
+          gh release create "v${{ steps.plan.outputs.version }}" \
+            --repo igou-io/igou-devenv \
+            --title "v${{ steps.plan.outputs.version }}" \
+            --generate-notes \
+            devcontainer.spdx.json
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run:
+```bash
+python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/release.yaml')); print('steps:', [s.get('name','uses') for s in d['jobs']['release']['steps']])"
+```
+Expected: lists the 6 steps (checkout, Decide version…, Log in to GHCR, Build and test…, Tag and push…, Generate SBOM, Tag and create…).
+
+- [ ] **Step 3: Lint with actionlint if available (optional)**
+
+Run: `command -v actionlint >/dev/null && actionlint .github/workflows/release.yaml || echo "actionlint not installed; skipping"`
+Expected: no errors (or skip message).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yaml
+git commit -m "feat(ci): release workflow (Mon 08:00 — CalVer image + tag + Release)"
+```
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (architecture tree)
+- Modify: `README.md` (release section)
+
+- [ ] **Step 1: Add the two workflows to CLAUDE.md's architecture tree**
+
+In `CLAUDE.md`, find the line:
+```
+.github/workflows/mise-lockfile-check.yaml  # CI: fails PRs whose mise.lock is stale vs mise.toml
+```
+Add immediately after it:
+```
+.github/workflows/release-prepare.yaml  # CI: Mon 06:30 — regenerate mise.lock + merge the mise PR
+.github/workflows/release.yaml          # CI: Mon 08:00 — weekly CalVer image + git tag + GitHub Release
+```
+
+- [ ] **Step 2: Add a "Weekly release" subsection to CLAUDE.md**
+
+In `CLAUDE.md`, immediately after the `### Bumping a CLI tool version` section (before `## Pre-push Requirements`), add:
+
+```markdown
+### Weekly release (CalVer)
+
+Every Monday two scheduled workflows run:
+
+1. `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` on the open
+   Renovate mise PR (`bin/release-prepare-mise`), waits for green, and merges
+   it — using `RELEASE_PAT`. If the bump breaks the build it files an issue and
+   leaves the PR open; the release still ships the rest.
+2. `release.yaml` (08:00 UTC) builds + tests `main`, publishes
+   `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` + `:latest`, pushes tag
+   `vYYYY.MM.DD`, and creates a GitHub Release (auto notes + SBOM). Skips weeks
+   with no changes; idempotent.
+
+Manual fallback: if `release-prepare` files an issue, regenerate the lock by
+hand — `make mise-lock` on the `renovate/mise-managed-cli-tools` branch, then
+push; it merges and rides the next weekly release.
+
+Requires the `RELEASE_PAT` repo secret (Contents + Pull-requests: read/write).
+```
+
+- [ ] **Step 3: Add a release section to README.md**
+
+In `README.md`, after the dependency-management bullets (the section ending around the `Trust anchors (mise itself, aqua-registry pin)` paragraph), add:
+
+```markdown
+### Weekly release
+
+A Monday pipeline cuts a dated release of the devcontainer:
+
+- `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` to merge the week's
+  Renovate mise PR (it can't merge itself — the hosted app can't regenerate the
+  lock).
+- `release.yaml` (08:00 UTC) publishes `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` +
+  `:latest`, tags `vYYYY.MM.DD`, and creates a GitHub Release with notes + SBOM.
+
+`:latest` always tracks `main`; the `:YYYY.MM.DD` tags are immutable weekly
+snapshots to pin or roll back to. Needs the `RELEASE_PAT` secret.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: document the weekly CalVer release pipeline"
+```
+
+---
+
+### Task 5: Push and integration-validate
+
+**Files:** none (validation only)
+
+> Note: `schedule:` triggers only fire from the **default branch**, so the crons won't run until this merges to `main`. Validate via `workflow_dispatch` on the feature branch first.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/weekly-calver-release
+```
+
+- [ ] **Step 2: Open the PR (so build.yaml validates the whole change)**
+
+```bash
+gh pr create --repo igou-io/igou-devenv --base main --head feat/weekly-calver-release \
+  --title "feat(ci): weekly CalVer release pipeline" \
+  --body "Implements docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md. See plan docs/superpowers/plans/2026-06-14-weekly-calver-release.md."
+```
+Confirm the PR's `build` check passes (workflow/doc-only change; the devcontainer build is unaffected).
+
+- [ ] **Step 3: Dry-run the release workflow from the branch**
+
+```bash
+gh workflow run release.yaml --repo igou-io/igou-devenv --ref feat/weekly-calver-release -f dry_run=true
+sleep 10
+gh run watch "$(gh run list --repo igou-io/igou-devenv --workflow release.yaml --limit 1 --json databaseId --jq '.[0].databaseId')" --repo igou-io/igou-devenv --exit-status --interval 20
+```
+Expected: success. The build+test runs; the tag/publish/release steps are skipped (dry_run). Confirms the version-guard and build path work.
+
+- [ ] **Step 4: Integration-test release-prepare against a synthetic mise PR**
+
+Create a throwaway PR that looks like Renovate's mise PR, then run the prepare workflow:
+```bash
+# from a fresh worktree of main:
+git worktree add /tmp/synthpr -b renovate/mise-managed-cli-tools origin/main
+cd /tmp/synthpr
+sed -i 's/^kind = "0.32.0"/kind = "0.33.0"/' mise.toml   # make the lock stale (adjust to a real newer version)
+git commit -am "chore(deps): synthetic mise bump for pipeline test"
+git push -u origin renovate/mise-managed-cli-tools
+gh pr create --repo igou-io/igou-devenv --base main --head renovate/mise-managed-cli-tools \
+  --title "TEST synthetic mise bump" --body "pipeline test — will be merged by release-prepare"
+
+gh workflow run release-prepare.yaml --repo igou-io/igou-devenv --ref feat/weekly-calver-release
+sleep 10
+gh run watch "$(gh run list --repo igou-io/igou-devenv --workflow release-prepare.yaml --limit 1 --json databaseId --jq '.[0].databaseId')" --repo igou-io/igou-devenv --exit-status --interval 30
+```
+Expected: the workflow regenerates `mise.lock`, pushes it, waits for the build to pass, and merges the synthetic PR. Verify the PR shows MERGED and `mise.toml`/`mise.lock` on `main` reflect the bump.
+
+> If the synthetic bump's version doesn't exist upstream, `make mise-lock` will fail — pick a real newer version (check `mise outdated` or the tool's releases) so the lock can resolve.
+
+- [ ] **Step 5: Clean up the synthetic test and finalize**
+
+```bash
+cd /workspace/igou-devenv && git worktree remove /tmp/synthpr --force
+```
+If the synthetic bump merged to `main`, either keep it (it's a real, valid tool bump) or revert it via a follow-up PR. Then merge the feature PR (Step 2) once its `build` check is green.
+
+- [ ] **Step 6: Post-merge sanity**
+
+After the feature PR merges, confirm the two workflows appear under Actions and are scheduled. The first real cron run is the next Monday; until then they remain `workflow_dispatch`-able.

--- a/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
+++ b/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
@@ -139,9 +139,12 @@ to `main`; `release.yml` adds the immutable `:YYYY.MM.DD` tag + Release.
 
 ## Testing
 
-- Both workflows are `workflow_dispatch`-able. `release.yml` has a `dry_run`
-  input (build + test only; no tag/publish/release) for safe manual validation
-  without waiting for Monday.
+- Both workflows are `workflow_dispatch`-able. `release.yaml` has `dry_run`
+  (build + test only; no tag/publish/release), `version` (tag override), and
+  `force` (bypass the skip guards) inputs — for safe manual validation and
+  on-demand test releases without waiting for Monday. Note: `workflow_dispatch`
+  is only registered once the workflow is on the default branch, so these run
+  post-merge.
 - `release-prepare.yml` validated against a real (or hand-created) mise PR:
   confirm lock regenerated, pushed, build watched, PR merged.
 - `make mise-lock` + `tests/test-mise-lockfile.sh` mechanics already verified in

--- a/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
+++ b/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
@@ -1,0 +1,156 @@
+# Weekly CalVer release pipeline — design
+
+- **Date:** 2026-06-14
+- **Status:** Approved (brainstorming), pending implementation plan
+- **Repo:** `igou-io/igou-devenv`
+
+## Problem / context
+
+Renovate (hosted Mend app) runs Sunday (`before 11pm on sunday`, UTC) and
+auto-merges most dependency updates. Two things are not fully hands-off:
+
+1. The grouped **mise-tools PR** can't auto-merge — the hosted app can't
+   regenerate `mise.lock` (no `postUpgradeTasks`), so the PR is stale and fails
+   CI (`mise-lockfile-check` + the build's locked `mise install`). Today a human
+   runs `make mise-lock` + push (Approach 3).
+2. There is no **release artifact** per week — `latest` floats at the tip of
+   `main`, with no dated, immutable snapshot or changelog.
+
+This design adds a **weekly Monday CalVer release** that (a) finishes the mise
+PR by regenerating its lock so it merges, and (b) cuts a dated release of the
+week's accumulated updates.
+
+The mise binary itself is already verified via GPG-signed checksums (no
+per-version SHA), so mise *binary* bumps remain fully automated and need no
+involvement here.
+
+## Goals
+
+- Eliminate the weekly manual `make mise-lock` step.
+- Produce a dated, immutable weekly release: CalVer-tagged image + git tag +
+  GitHub Release with notes and SBOM.
+- Keep the supply-chain posture: lockfile stays authoritative; the ≥10-day
+  stability window is preserved.
+- No broken `latest`: a bad weekly bump must not ship.
+
+## Non-goals
+
+- Replacing the hosted Renovate app (it keeps proposing all updates).
+- Reimplementing version discovery / stability windows (Renovate already does
+  this across mise's heterogeneous backends).
+- Releasing more often than weekly.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Pipeline scope | **Hybrid (Z)** — Renovate *proposes* mise versions (keeps its `mise` manager + `minimumReleaseAge: 10d`); the pipeline owns the **lock + release**. |
+| Release artifact | CalVer image (`:YYYY.MM.DD` + `:latest`) **+** git tag `vYYYY.MM.DD` **+** GitHub Release (auto notes + SBOM). |
+| Merge model | Open/keep a PR (Renovate's mise PR); the prepare job pushes the lock, waits for green, merges. |
+| Stability window | `N = 10` days, kept in Renovate config (unchanged). |
+| CalVer format | `YYYY.MM.DD` (e.g. `2026.06.15`); git tag `vYYYY.MM.DD`. |
+| Schedule (UTC) | `release-prepare` Mon **06:30**, `release` Mon **08:00**. |
+| Merge mechanism | Job-poll-then-merge with `RELEASE_PAT` (repo has `allow_auto_merge: false`, `main` unprotected — GitHub-native auto-merge is not used). |
+
+## Architecture
+
+Three pieces; only two are new.
+
+### 1. Renovate (Sunday) — unchanged
+Keeps all managers including `mise`, `automerge: true`, `minimumReleaseAge: 10d`.
+Non-mise PRs (base image, GitHub Actions, Python, mise binary) auto-merge to
+`main` on green, as today. The grouped `renovate/mise-managed-cli-tools` PR
+opens but stays red (stale lock) — handled by the prepare job below.
+
+### 2. `.github/workflows/release-prepare.yml` (new) — cron Mon 06:30 UTC
+Finishes the mise PR so it can merge.
+
+```
+trigger: schedule (Mon 06:30 UTC) + workflow_dispatch
+steps:
+  1. checkout main with RELEASE_PAT
+  2. find the open PR with head branch "renovate/mise-managed-cli-tools"
+     - none open  -> log "no mise updates this week", exit 0
+  3. checkout that PR branch
+  4. export GITHUB_TOKEN; run `make mise-lock`
+     - on failure (e.g. a version yanked) -> open/update a tracking issue, exit 1
+  5. if mise.lock changed: commit + push to the PR branch with RELEASE_PAT
+     (a PAT push re-triggers build.yaml + mise-lockfile-check; GITHUB_TOKEN would not)
+  6. wait for the PR's `build` check to succeed (`gh pr checks <pr> --watch`)
+     - on red -> open/update a tracking issue, exit 1 (PR stays open for a human)
+  7. merge the PR: `gh pr merge <pr> --squash --delete-branch` (RELEASE_PAT)
+```
+
+Failure here never blocks the release: a broken mise bump leaves its PR open +
+an issue filed; the 08:00 release still ships the rest of the week's updates.
+
+### 3. `.github/workflows/release.yml` (new) — cron Mon 08:00 UTC
+Cuts the dated release from whatever is on `main`.
+
+```
+trigger: schedule (Mon 08:00 UTC) + workflow_dispatch (with `dry_run` input)
+permissions: contents: write, packages: write
+steps:
+  1. checkout main
+  2. VERSION=$(date -u +%Y.%m.%d)        # provided via workflow env at runtime, not committed
+  3. if tag vVERSION already exists       -> exit 0 (idempotent re-run guard)
+     if main has not advanced since the latest v* tag -> exit 0 (nothing to release)
+  4. build + test the devcontainer (devcontainers/ci, runCmd tests/run-all.sh)
+  5. publish image ghcr.io/igou-io/igou-devenv:$VERSION and :latest
+  6. generate SBOM (existing anchore/sbom-action step)
+  7. push git tag v$VERSION
+  8. create GitHub Release v$VERSION:
+       - auto-generated notes (merged PRs since the previous tag)
+       - attach the SBOM artifact
+  dry_run=true: do steps 1-4 only (build+test), skip 5-8
+```
+
+`:latest` continues to be published by the existing `build.yaml` on every push
+to `main`; `release.yml` adds the immutable `:YYYY.MM.DD` tag + Release.
+
+## Versioning
+
+- Image tags: `ghcr.io/igou-io/igou-devenv:2026.06.15` and `:latest`.
+- Git tag: `v2026.06.15`.
+- The CalVer value is computed at run time (`date -u +%Y.%m.%d`); it is never
+  committed to a file (avoids the harness's no-`Date.now()`-in-scripts concern
+  and keeps the repo free of a version-bump commit).
+
+## Prerequisites
+
+- **`RELEASE_PAT`** repo secret — fine-grained PAT on `igou-io/igou-devenv`
+  with **Contents: read/write** + **Pull requests: read/write** (classic
+  equivalent: `repo`). Required because the prepare job's lock push must
+  re-trigger CI and it merges the PR. *(Provisioned 2026-06-14.)*
+- No repo-settings changes required (`main` unprotected, `allow_auto_merge`
+  off → job-poll-then-merge). Optional hardening: enable "Allow auto-merge" +
+  branch-protect `main` requiring the `build` check.
+- Runner has `podman` (ubuntu-latest) — already relied on by `make mise-lock`.
+
+## Failure handling & edge cases
+
+- **mise bump breaks the build / lock regen fails** → PR stays open, tracking
+  issue filed; `release.yml` still ships the good (non-mise) updates. Human
+  fixes the PR; it rides the next weekly release.
+- **No updates this week** (`main` unchanged since last tag) → `release.yml`
+  skips; no empty release.
+- **Idempotent** → today's `vYYYY.MM.DD` tag already present → skip.
+- **No open mise PR** → prepare job is a no-op; release proceeds normally.
+
+## Testing
+
+- Both workflows are `workflow_dispatch`-able. `release.yml` has a `dry_run`
+  input (build + test only; no tag/publish/release) for safe manual validation
+  without waiting for Monday.
+- `release-prepare.yml` validated against a real (or hand-created) mise PR:
+  confirm lock regenerated, pushed, build watched, PR merged.
+- `make mise-lock` + `tests/test-mise-lockfile.sh` mechanics already verified in
+  CI (`mise-lockfile-check`).
+
+## Out of scope / future
+
+- Retag-instead-of-rebuild in `release.yml` (copy the just-built `latest`
+  digest to the CalVer tag) to avoid the second Monday build — an optimization;
+  the spec rebuilds for determinism.
+- GitHub App token instead of a PAT (more secure; more setup).
+- Branch protection / native auto-merge hardening.


### PR DESCRIPTION
Implements the weekly Monday CalVer release pipeline.

**Spec:** `docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md`
**Plan:** `docs/superpowers/plans/2026-06-14-weekly-calver-release.md`

## What
- `bin/release-prepare-mise` — regenerates `mise.lock` on Renovate's open mise PR, waits for green, squash-merges (hosted Renovate can't regenerate the lock).
- `.github/workflows/release-prepare.yaml` (Mon 06:30 UTC) — runs the script with `RELEASE_PAT`; files an issue on failure.
- `.github/workflows/release.yaml` (Mon 08:00 UTC) — build+test, publish `:YYYY.MM.DD` + `:latest`, push annotated tag `vYYYY.MM.DD`, GitHub Release (auto notes + SBOM). Idempotent; skips empty weeks; `dry_run` input.
- Docs updated (CLAUDE.md, README.md).

## Prereq
`RELEASE_PAT` secret (Contents + Pull-requests: read/write) — provisioned. Failure-issue uses the built-in `GITHUB_TOKEN` (+ `issues: write`), so no Issues scope needed on the PAT.

## Validation
Static checks pass (shellcheck clean, both YAMLs parse); spec-compliance + code-quality reviewed. The new cron/dispatch workflows can only be exercised once on `main` (GitHub registers `workflow_dispatch` from the default branch) — post-merge: `release.yaml` dry-run, and `release-prepare` runs for real on the next Renovate mise PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)