### PR TITLE
fix(ci): set git identity before annotated release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "v${{ steps.plan.outputs.version }}" -m "v${{ steps.plan.outputs.version }}"
           git push origin "v${{ steps.plan.outputs.version }}"
           gh release create "v${{ steps.plan.outputs.version }}" \


### PR DESCRIPTION
The release job's annotated `git tag -a` failed with "Committer identity unknown" — surfaced by the first live forced test release (image + SBOM steps succeeded; the tag/release step failed). Sets the github-actions[bot] git identity before tagging. Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)