### PR TITLE
refactor(ci): release by promoting the tested :latest digest (no rebuild)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,18 @@
 name: release (weekly CalVer)
 
-# Monday 08:00 UTC. Snapshots whatever is on main (the week's merged Renovate
-# updates + the mise PR merged by release-prepare) into a dated release:
-# image :YYYY.MM.DD + :latest, git tag vYYYY.MM.DD, and a GitHub Release with
-# auto-generated notes + the SBOM. Idempotent; skips weeks with no changes.
+# Monday 08:00 UTC. PROMOTES the already-built, already-tested :latest image
+# (build.yaml builds+tests+pushes :latest on every push to main) to an immutable
+# dated tag by digest — no rebuild — so the released image is byte-identical to
+# what CI tested. Then pushes git tag vYYYY.MM.DD and a GitHub Release with auto
+# notes + SBOM. Idempotent; skips weeks with no changes.
 #
-# Also manually runnable from the Actions tab / `gh workflow run release.yaml`
-# with inputs below — handy for testing the pipeline on demand.
+# The test gate lives in build.yaml (push-to-main build runs tests/run-all.sh and
+# only pushes :latest on success); release.yaml trusts that green and promotes it.
+#
+# Also manually runnable (Actions tab / `gh workflow run release.yaml`):
+#   dry_run  — resolve + plan only; no promote/tag/release
+#   version  — tag override (default today UTC YYYY.MM.DD); use a unique value for test promotions
+#   force    — promote even if the tag exists or main hasn't advanced (manual test runs)
 
 on:
   schedule:
@@ -14,21 +20,25 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Build + test only; do not tag/publish/release"
+        description: "Resolve + plan only; do not promote/tag/release"
         type: boolean
         default: false
       version:
-        description: "Version/tag override (default: today UTC YYYY.MM.DD). Use a unique value for repeat test releases, e.g. 0.0.0-test."
+        description: "Version/tag override (default: today UTC YYYY.MM.DD). Use a unique value for test promotions, e.g. 0.0.0-test."
         type: string
         default: ""
       force:
-        description: "Release even if the tag exists or main hasn't advanced (for manual test runs)"
+        description: "Promote even if the tag exists or main hasn't advanced (for manual test runs)"
         type: boolean
         default: false
 
 permissions:
   contents: write
   packages: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -45,16 +55,16 @@ jobs:
           if [ -z "$VERSION" ]; then VERSION="$(date -u +%Y.%m.%d)"; fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if [ "${{ inputs.force }}" = "true" ]; then
-            echo "force=true — releasing v$VERSION regardless of guards."
+            echo "force=true — promoting v$VERSION regardless of guards." | tee -a "$GITHUB_STEP_SUMMARY"
             echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists — skipping (use force + a unique version to re-release)."
+            echo "Skipped: tag v$VERSION already exists." | tee -a "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           last="$(git tag --list 'v*' --sort=-creatordate | head -1)"
           if [ -n "$last" ] && [ -z "$(git log "$last"..HEAD --oneline)" ]; then
-            echo "main has not advanced since $last — skipping."
+            echo "Skipped: main has not advanced since $last." | tee -a "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -63,23 +73,21 @@ jobs:
         if: steps.plan.outputs.proceed == 'true'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build and test devcontainer
+      - name: Resolve the tested :latest digest
+        id: img
         if: steps.plan.outputs.proceed == 'true'
-        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          push: ${{ inputs.dry_run && 'never' || 'always' }}
-          imageName: ghcr.io/igou-io/igou-devenv
-          runCmd: /workspace/igou-devenv/tests/run-all.sh
+        run: |
+          digest=$(docker buildx imagetools inspect ghcr.io/igou-io/igou-devenv:latest --format '{{.Manifest.Digest}}')
+          [ -n "$digest" ] || { echo "::error::could not resolve :latest digest"; exit 1; }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Promoting ghcr.io/igou-io/igou-devenv@$digest -> :${{ steps.plan.outputs.version }}" | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Tag and push the CalVer image
+      - name: Promote the digest to the CalVer tag
         if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
         run: |
-          # devcontainers/ci (push: always) also --loads :latest into the local
-          # docker daemon; we retag that exact image so the CalVer tag == what was tested.
-          docker tag  ghcr.io/igou-io/igou-devenv:latest ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
-          docker push ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          docker buildx imagetools create \
+            --tag ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }} \
+            ghcr.io/igou-io/igou-devenv@${{ steps.img.outputs.digest }}
 
       - name: Generate SBOM
         if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ push; it merges and rides the next weekly release.
 
 Manual / test release: `release.yaml` is also `workflow_dispatch`-able (Actions
 tab or `gh workflow run release.yaml`):
-- `-f dry_run=true` — build + test only, no publish (safe, repeatable).
+- `-f dry_run=true` — resolve + plan only, no promote/tag/release (safe, repeatable).
 - `-f version=0.0.0-test -f force=true` — cut a throwaway release on demand
   (unique `version` avoids clashing with the real weekly CalVer tags; `force`
   bypasses the "tag exists / main not advanced" skip guards). Delete the test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,13 @@ Every Monday two scheduled workflows run:
    Renovate mise PR (`bin/release-prepare-mise`), waits for green, and merges
    it — using `RELEASE_PAT`. If the bump breaks the build it files an issue and
    leaves the PR open; the release still ships the rest.
-2. `release.yaml` (08:00 UTC) builds + tests `main`, publishes
-   `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` + `:latest`, pushes tag
-   `vYYYY.MM.DD`, and creates a GitHub Release (auto notes + SBOM). Skips weeks
-   with no changes; idempotent.
+2. `release.yaml` (08:00 UTC) **promotes** the already-tested
+   `ghcr.io/igou-io/igou-devenv:latest` image (built + tested by `build.yaml` on
+   every push to `main`) to the immutable dated tag `:YYYY.MM.DD` **by digest —
+   no rebuild** — so the released image is byte-identical to what CI tested. It
+   then pushes tag `vYYYY.MM.DD` and creates a GitHub Release (auto notes +
+   SBOM). `:latest` is owned by `build.yaml`; release no longer publishes
+   `:latest`. Skips weeks with no changes; idempotent.
 
 Manual fallback: if `release-prepare` files an issue, regenerate the lock by
 hand — `make mise-lock` on the `renovate/mise-managed-cli-tools` branch, then

--- a/README.md
+++ b/README.md
@@ -339,11 +339,14 @@ A Monday pipeline cuts a dated release of the devcontainer:
 - `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` to merge the week's
   Renovate mise PR (it can't merge itself — the hosted app can't regenerate the
   lock).
-- `release.yaml` (08:00 UTC) publishes `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` +
-  `:latest`, tags `vYYYY.MM.DD`, and creates a GitHub Release with notes + SBOM.
+- `release.yaml` (08:00 UTC) promotes the tested `:latest` digest to
+  `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` (no rebuild — byte-identical to what
+  CI tested), tags `vYYYY.MM.DD`, and creates a GitHub Release with notes + SBOM.
 
-`:latest` always tracks `main`; the `:YYYY.MM.DD` tags are immutable weekly
-snapshots to pin or roll back to. Needs the `RELEASE_PAT` secret.
+`:latest` tracks `main` via `build.yaml` (which builds + tests + pushes it on
+every push to `main`); the `:YYYY.MM.DD` tags are immutable weekly snapshots —
+promoted from that same tested `:latest` digest — to pin or roll back to. Needs
+the `RELEASE_PAT` secret.
 
 `release.yaml` can also be run on demand (`gh workflow run release.yaml`):
 `-f dry_run=true` for build+test only, or `-f version=0.0.0-test -f force=true`

--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ promoted from that same tested `:latest` digest — to pin or roll back to. Need
 the `RELEASE_PAT` secret.
 
 `release.yaml` can also be run on demand (`gh workflow run release.yaml`):
-`-f dry_run=true` for build+test only, or `-f version=0.0.0-test -f force=true`
-to cut a throwaway test release.
+`-f dry_run=true` for resolve+plan only, or `-f version=0.0.0-test -f force=true`
+to cut a throwaway test promotion.
 
 ## CI
 

--- a/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
+++ b/docs/superpowers/specs/2026-06-14-weekly-calver-release-design.md
@@ -95,18 +95,25 @@ steps:
   2. VERSION=$(date -u +%Y.%m.%d)        # provided via workflow env at runtime, not committed
   3. if tag vVERSION already exists       -> exit 0 (idempotent re-run guard)
      if main has not advanced since the latest v* tag -> exit 0 (nothing to release)
-  4. build + test the devcontainer (devcontainers/ci, runCmd tests/run-all.sh)
-  5. publish image ghcr.io/igou-io/igou-devenv:$VERSION and :latest
+  4. resolve the tested :latest digest (docker buildx imagetools inspect) — the
+     image build.yaml built, tested (tests/run-all.sh), and pushed on the last
+     push to main
+  5. promote that digest to ghcr.io/igou-io/igou-devenv:$VERSION by digest
+     (docker buildx imagetools create) — no rebuild; byte-identical to what CI
+     tested
   6. generate SBOM (existing anchore/sbom-action step)
   7. push git tag v$VERSION
   8. create GitHub Release v$VERSION:
        - auto-generated notes (merged PRs since the previous tag)
        - attach the SBOM artifact
-  dry_run=true: do steps 1-4 only (build+test), skip 5-8
+  dry_run=true: do steps 1-4 only (resolve + plan), skip 5-8
 ```
 
 `:latest` continues to be published by the existing `build.yaml` on every push
-to `main`; `release.yml` adds the immutable `:YYYY.MM.DD` tag + Release.
+to `main`; `release.yml` promotes that exact tested `:latest` digest to the
+immutable `:YYYY.MM.DD` tag + Release. The test gate lives in `build.yaml`
+(push-to-main only pushes `:latest` on a green `tests/run-all.sh`); `release.yml`
+trusts that green and promotes — it no longer publishes `:latest` itself.
 
 ## Versioning
 
@@ -152,8 +159,11 @@ to `main`; `release.yml` adds the immutable `:YYYY.MM.DD` tag + Release.
 
 ## Out of scope / future
 
-- Retag-instead-of-rebuild in `release.yml` (copy the just-built `latest`
+- ~~Retag-instead-of-rebuild in `release.yml` (copy the just-built `latest`
   digest to the CalVer tag) to avoid the second Monday build — an optimization;
-  the spec rebuilds for determinism.
+  the spec rebuilds for determinism.~~ **Implemented:** `release.yaml` now
+  promotes the tested `:latest` digest to the CalVer tag (`docker buildx
+  imagetools create`) instead of rebuilding — no second Monday build, and the
+  released image is byte-identical to what `build.yaml` tested.
 - GitHub App token instead of a PAT (more secure; more setup).
 - Branch protection / native auto-merge hardening.


### PR DESCRIPTION
Per the multi-agent review, make the weekly release a **digest promotion** instead of a rebuild.

## Why
`build.yaml` already builds + tests + pushes `:latest` on every push to `main` (gating the push on `tests/run-all.sh`). The old `release.yaml` rebuilt `main` again at 08:00 just to retag — wasteful, and the `docker tag :latest -> :VERSION` step could race a concurrent `:latest` push.

## What
`release.yaml` now: resolves the digest `:latest` points to → `docker buildx imagetools create` promotes that exact digest to `:YYYY.MM.DD` (server-side, no pull/rebuild) → SBOM → annotated git tag + GitHub Release.
- **Released image == tested image**, by digest (not a hopefully-identical rebuild).
- Removes the retag race; `:latest` is owned by `build.yaml`, `:YYYY.MM.DD` by `release.yaml`.
- Added `concurrency: group: release` (prevents cron+dispatch tag races).
- Trust boundary documented in the workflow + CLAUDE.md/README/spec: release trusts build.yaml's green `:latest`.

`dry_run` now = resolve+plan only (no build). `version`/`force` preserved.

Reviewed (spec + quality, Opus): APPROVED; digest-resolve→server-retag verified correct, gating/trust-boundary sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)