### PR TITLE
feat(make): release targets for on-demand (mid-week) releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ make test-env           # Test environment switching functions
 make renovate-validate  # Validate renovate.json config
 GITHUB_TOKEN=... make renovate-dry-run  # Dry-run Renovate locally
 make e2e                # Full end-to-end: rebuild devcontainer + all tests
+make release            # Cut a release now: promote tested :latest -> CalVer tag + Release
+make release-dry-run    # Dry-run the release (resolve + plan only; no side effects)
+make release-prepare    # On demand: regenerate mise.lock on the open Renovate mise PR and merge it
+make release VERSION=2026.06.18-2 FORCE=true  # override the tag / bypass skip guards
 claude-run              # Launch Claude in the container (see bin/claude-run)
 claude-run -e ocp-rosa  # Launch with resolved cluster credentials
 claude-run --shell      # Drop to bash inside the container
@@ -140,8 +144,10 @@ Manual fallback: if `release-prepare` files an issue, regenerate the lock by
 hand — `make mise-lock` on the `renovate/mise-managed-cli-tools` branch, then
 push; it merges and rides the next weekly release.
 
-Manual / test release: `release.yaml` is also `workflow_dispatch`-able (Actions
-tab or `gh workflow run release.yaml`):
+Manual / test release: use the `make release*` targets (`make release`,
+`make release-dry-run`, `make release-prepare`; they wrap the dispatches and need
+a gh token with Actions: write), or drive `release.yaml` directly — it is
+`workflow_dispatch`-able (Actions tab or `gh workflow run release.yaml`):
 - `-f dry_run=true` — resolve + plan only, no promote/tag/release (safe, repeatable).
 - `-f version=0.0.0-test -f force=true` — cut a throwaway release on demand
   (unique `version` avoids clashing with the real weekly CalVer tags; `force`

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SSH_MOUNT = $(shell [ -S "$$SSH_AUTH_SOCK" ] && echo '--mount type=bind,source=$
 
 .DEFAULT_GOAL := help
 
-.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock
+.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock release release-dry-run release-prepare release-watch
 
 
 ## Build the devcontainer image (with cache)
@@ -159,6 +159,41 @@ opencode-build:
 		exit 1; \
 	fi; \
 	podman build -t ghcr.io/igou-io/opencode:latest -f $$OPENCODE_DIR/Containerfile $$OPENCODE_DIR
+
+# ---------------------------------------------------------------------------
+# Release (CalVer) — dispatch the GitHub Actions release workflows on demand
+# (e.g. a mid-week release). These wrap `gh workflow run`, so they need a gh
+# token with Actions: write (or use the Actions UI). The Monday cron runs the
+# equivalents automatically. Release PROMOTES the current tested :latest by
+# digest, so make sure the latest push to main has a green build.yaml first.
+# ---------------------------------------------------------------------------
+RELEASE_REPO ?= igou-io/igou-devenv
+WF           ?= release.yaml
+
+## Cut a release now: promote the tested :latest to a dated CalVer tag + Release.
+## Optional: VERSION=2026.06.18-2 (tag override), FORCE=true (ignore skip guards).
+release:
+	gh workflow run release.yaml --repo $(RELEASE_REPO) \
+		$(if $(VERSION),-f version=$(VERSION)) \
+		$(if $(FORCE),-f force=$(FORCE))
+	@$(MAKE) --no-print-directory release-watch
+
+## Dry-run a release: resolve + plan only (no promote/tag/release).
+release-dry-run:
+	gh workflow run release.yaml --repo $(RELEASE_REPO) -f dry_run=true
+	@$(MAKE) --no-print-directory release-watch
+
+## On-demand mise prep: regenerate mise.lock on the open Renovate mise PR and merge it.
+release-prepare:
+	gh workflow run release-prepare.yaml --repo $(RELEASE_REPO)
+	@$(MAKE) --no-print-directory release-watch WF=release-prepare.yaml
+
+## Watch the latest run of WF (default release.yaml).
+release-watch:
+	@sleep 8; \
+	id=$$(gh run list --repo $(RELEASE_REPO) --workflow $(WF) --limit 1 --json databaseId --jq '.[0].databaseId'); \
+	echo "Watching $(WF) run $$id ..."; \
+	gh run watch "$$id" --repo $(RELEASE_REPO) --exit-status
 
 help: ## Show available targets
 	@awk '/^## /{if(!desc) desc=substr($$0,4); next} /^[a-zA-Z_-]+:/{if(desc){split($$1,a,":"); printf "  \033[36m%-25s\033[0m %s\n", a[1], desc} desc=""} !/^##/ && !/^[a-zA-Z_-]+:/{desc=""}' $(MAKEFILE_LIST)


### PR DESCRIPTION
Adds `make` wrappers for the release workflows so a mid-week release is one command:

- `make release` — promote the tested `:latest` to a dated CalVer tag + Release (optional `VERSION=`, `FORCE=`)
- `make release-dry-run` — resolve + plan only (no side effects)
- `make release-prepare` — regenerate mise.lock on the open Renovate mise PR and merge it
- `make release-watch` — watch the latest run

They wrap `gh workflow run` (need a gh token with Actions: write). CLAUDE.md updated (Common Commands + release section).

Verified `make release-dry-run` dispatched and ran green (resolve+plan only) via the igou-io token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)