### PR TITLE
ci(mise): release-prepare uses native auto-merge (drop poll/sleep)

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -2,9 +2,11 @@ name: release-prepare (weekly mise lock)
 
 # Monday 06:30 UTC (after Renovate's Sunday run). Renovate cannot regenerate
 # mise.lock (hosted Mend app, no postUpgradeTasks), so its mise-tools PR is
-# stale. This job regenerates the lock, pushes it (which re-triggers CI), waits
-# for green, and merges — using RELEASE_PAT so the push actually re-triggers
-# workflows (a GITHUB_TOKEN push would not). The 08:00 release.yaml then ships.
+# stale. This job regenerates the lock, pushes it (which re-triggers CI), and
+# enables GitHub native auto-merge — using RELEASE_PAT so the push re-triggers
+# workflows (a GITHUB_TOKEN push would not) and the bot can merge. GitHub
+# squash-merges the PR once the required `build` check passes; this job no longer
+# blocks waiting. The 08:00 release.yaml then ships.
 
 on:
   schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ tests/
 renovate.json            # Renovate config with custom regex manager for Dockerfile ARGs
 .github/workflows/build.yaml         # CI: builds full devcontainer on push/PR via devcontainers/ci
 .github/workflows/mise-lockfile-check.yaml  # CI: fails PRs whose mise.lock is stale vs mise.toml
-.github/workflows/release-prepare.yaml  # CI: Mon 06:30 — regenerate mise.lock + merge the mise PR
+.github/workflows/release-prepare.yaml  # CI: Mon 06:30 — regenerate mise.lock + auto-merge the mise PR
 .github/workflows/release.yaml          # CI: Mon 08:00 — weekly CalVer image + git tag + GitHub Release
 ```
 
@@ -104,11 +104,13 @@ Tools managed by mise (see Architecture table) are pinned in `mise.toml`
 with per-asset checksums in `mise.lock`. Renovate bumps the *version* in
 `mise.toml` but cannot regenerate `mise.lock` — the hosted Mend app cannot run
 postUpgradeTasks — so its raw PRs are stale and fail the `mise-lockfile-check`
-CI guard. There is no auto-commit: on a flagged Renovate PR, regenerate the lock
-on its branch (`make mise-lock`), commit and push the updated `mise.lock`, and
-it then passes and automerges. (The mise binary itself is verified against
-mise's GPG-signed checksums, so a version-only `MISE_VERSION` bump needs no
-follow-up.) To bump a tool manually:
+CI guard. `release-prepare.yaml` handles this automatically (Mondays, or on
+demand via `make release-prepare`): it regenerates the lock on the open mise PR
+and enables auto-merge. You only step in if a bump genuinely breaks the build
+(release-prepare files an issue) — then fix it by hand on the
+`renovate/mise-managed-cli-tools` branch (`make mise-lock`, commit, push). (The
+mise binary itself is verified against mise's GPG-signed checksums, so a
+version-only `MISE_VERSION` bump needs no follow-up.) To bump a tool manually:
 
 ```bash
 # 1. Edit the version in mise.toml
@@ -129,9 +131,14 @@ confirming the upstream change was deliberate.
 Every Monday two scheduled workflows run:
 
 1. `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` on the open
-   Renovate mise PR (`bin/release-prepare-mise`), waits for green, and merges
-   it — using `RELEASE_PAT`. If the bump breaks the build it files an issue and
-   leaves the PR open; the release still ships the rest.
+   Renovate mise PR (`bin/release-prepare-mise`) and **enables GitHub
+   auto-merge** — using `RELEASE_PAT`; GitHub squash-merges the PR once the
+   required `build` check passes (the job no longer blocks waiting). The mise
+   group is `automerge:false` in `renovate.json` so this job is its sole merger.
+   If the lock can't be regenerated (e.g. a version that won't resolve) it files
+   an issue and leaves the PR open; a bump that locks but then fails the build
+   just leaves the PR open (red, auto-merge pending) — the release still ships
+   the rest.
 2. `release.yaml` (08:00 UTC) **promotes** the already-tested
    `ghcr.io/igou-io/igou-devenv:latest` image (built + tested by `build.yaml` on
    every push to `main`) to the immutable dated tag `:YYYY.MM.DD` **by digest —

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ GITHUB_TOKEN=ghp_... make renovate-dry-run # see what would be updated
 
 A Monday pipeline cuts a dated release of the devcontainer:
 
-- `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` to merge the week's
-  Renovate mise PR (it can't merge itself — the hosted app can't regenerate the
-  lock).
+- `release-prepare.yaml` (06:30 UTC) regenerates `mise.lock` on the week's
+  Renovate mise PR and enables GitHub auto-merge (it can't merge itself — the
+  hosted app can't regenerate the lock); GitHub merges it once `build` passes.
 - `release.yaml` (08:00 UTC) promotes the tested `:latest` digest to
   `ghcr.io/igou-io/igou-devenv:YYYY.MM.DD` (no rebuild — byte-identical to what
   CI tested), tags `vYYYY.MM.DD`, and creates a GitHub Release with notes + SBOM.

--- a/bin/release-prepare-mise
+++ b/bin/release-prepare-mise
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Finish the open Renovate mise-tools PR so it can merge: regenerate mise.lock,
-# push it (a PAT push re-triggers CI), wait for the build to pass, then
-# squash-merge. Hosted Renovate cannot regenerate the lock itself.
+# push it (a PAT push re-triggers CI), then enable GitHub native auto-merge —
+# the PR squash-merges automatically once the required `build` check passes.
+# Hosted Renovate cannot regenerate the lock itself; the mise group has
+# automerge:false in renovate.json, so this job is its sole merger.
 #
 # Requires (set by the workflow):
-#   GH_TOKEN      a token that re-triggers workflows (RELEASE_PAT) — used by gh + git
+#   GH_TOKEN      a token that re-triggers workflows + can merge (RELEASE_PAT)
 #   GITHUB_TOKEN  default token — used by `make mise-lock` for GitHub API rate limits
-# Also requires: podman, make, gh, git.
+# Also requires: podman, make, gh, git; repo "Allow auto-merge" enabled and a
+# branch ruleset requiring the `build` check.
 set -euo pipefail
 
 REPO="igou-io/igou-devenv"
@@ -32,11 +35,15 @@ else
   git push
 fi
 
-# Let any freshly-pushed (or freshly-opened-PR) checks register before watching,
-# so `gh pr checks --watch` doesn't exit early on a transient "no checks yet".
-sleep 30
-echo "Waiting for checks on PR #$pr to complete..."
-gh pr checks "$pr" --repo "$REPO" --watch --interval 30
-
-gh pr merge "$pr" --repo "$REPO" --squash --delete-branch
-echo "Merged mise PR #$pr"
+# Enable auto-merge: GitHub squash-merges once the required `build` check is
+# green. No poll/sleep — the merge happens natively when CI passes.
+if ! gh pr merge "$pr" --repo "$REPO" --squash --auto --delete-branch; then
+  state="$(gh pr view "$pr" --repo "$REPO" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+  if [ "$state" = "MERGED" ]; then
+    echo "PR #$pr already merged."
+  else
+    echo "::error::could not enable auto-merge on PR #$pr (state=$state)"
+    exit 1
+  fi
+fi
+echo "Auto-merge enabled on PR #$pr — it merges when build passes."

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,9 @@
     },
     {
       "matchManagers": ["mise"],
-      "groupName": "mise-managed cli tools"
+      "groupName": "mise-managed cli tools",
+      "description": "automerge:false — release-prepare.yaml owns merging this PR (it regenerates mise.lock then enables GitHub auto-merge); this avoids racing Renovate's own automerge.",
+      "automerge": false
     },
     {
       "matchManagers": ["custom.regex"],


### PR DESCRIPTION
Simplifies `release-prepare` to enable GitHub **native auto-merge** on the mise PR instead of `sleep` + `gh pr checks --watch` + synchronous merge. Now that `allow_auto_merge` is on and a ruleset requires `build`, the job just regenerates the lock, pushes, and enables auto-merge — exits in seconds (no ~4-min runner hold), no check-registration race. `renovate.json` mise group → `automerge:false` so release-prepare is the sole merger. Docs reconciled.

Tested by enabling auto-merge on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)