### PR TITLE
ci: stop submitting image SBOM to the dependency graph

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,4 +41,12 @@ jobs:
           artifact-name: devcontainer-sbom
           output-file: devcontainer.spdx.json
           format: spdx-json
-          dependency-snapshot: true
+          # Keep the SBOM as a workflow artifact, but do NOT submit it to the
+          # GitHub dependency graph. The image bundles many third-party Go/npm
+          # CLIs (podman, buildah, kubectl, argocd, code-server, ...); submitting
+          # their embedded module SBOMs floods Dependabot with hundreds of CVE
+          # alerts for upstream binaries we don't build and can't patch here.
+          # Those are remediated by tool-version bumps via Renovate + mise.toml,
+          # not by this repo, so the alerts are non-actionable noise that buries
+          # any real signal. See git history / PR for the investigation.
+          dependency-snapshot: false


### PR DESCRIPTION
## Why
The 169 Dependabot alerts on `main` (3 critical, 75 high, 82 moderate, 9 low) are **not** in code or dependencies this repo owns. Every alert's `manifest_path` is an in-image binary (`.../usr/bin/podman`, `.../kubectl`, `.../argocd`, …); the repo has no `go.mod`/`go.sum`/`pom.xml`/`package-lock.json`.

They come from `anchore/sbom-action` running with `dependency-snapshot: true`, which submits the **image SBOM** to GitHub's dependency graph. That turns every Go/npm module statically linked into the bundled upstream CLIs into a CVE alert. code-server (#82) was about to make it worse by adding a full `node_modules` tree.

## Change
`dependency-snapshot: true` → `false`. The SBOM is still generated and uploaded as the `devcontainer-sbom` artifact for audit — it just no longer floods the dependency graph.

## Remediation model unchanged
Real upstream-tool CVEs are still handled where they belong: **Renovate + `mise.toml` + the weekly CalVer release** bump the pinned tool versions.

## Follow-up
The existing 169 alerts are being dismissed (`tolerable_risk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)