### PR TITLE
fix(ci): pass GITHUB_TOKEN as a BuildKit secret, not a build arg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -208,11 +208,18 @@ ENV MISE_DATA_DIR=/opt/mise \
 # GITHUB_TOKEN is consumed by mise's GitHub-attestations / aqua release-tag
 # lookups during install. The 60/hr unauthenticated quota is too small to
 # survive a full rebuild of 21 aqua-managed tools; the token bumps it to
-# 5000/hr. Declared as ARG (not ENV) so the secret stays out of the final
-# image — it's only available to this single RUN layer.
+# 5000/hr.
+#
+# Provided via a BuildKit secret mount (--mount=type=secret), so the value is
+# NEVER written to an image layer or recorded in build history. CI builds pass
+# it with `docker buildx build --secret id=github_token,env=GITHUB_TOKEN` and do
+# NOT set the build ARG, so the published image is token-free. The ARG below is
+# only a fallback for local `make`/Cursor builds, which can't pass a build secret
+# through devcontainer.json — a token baked into a local, never-published image
+# is acceptable. (Build args leak into image history; secrets do not.)
 ARG GITHUB_TOKEN=""
-RUN set -eux; \
-    export GITHUB_TOKEN="${GITHUB_TOKEN}"; \
+RUN --mount=type=secret,id=github_token set -eux; \
+    export GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || printf '%s' "${GITHUB_TOKEN}")"; \
     mise install --yes; \
     # Symlink installed binaries into /usr/local/bin so they're on PATH
     # for any user without shell activation. mise's per-tool layout is not
@@ -363,10 +370,12 @@ ARG OPENCODE_SHA256_X64="f23bcabaf3f2fa9b66b8011813606501885aa6bfdf31030d4c061bd
 ARG OPENCODE_SHA256_ARM64="58bdd72718817043f9e3328c9f78acc6c667dd26e5fd013a6cf3c03593de2374"
 # GITHUB_TOKEN authenticates the release-age API call below. Without it the
 # 60/hr unauthenticated quota gets exhausted on busy CI runners and the build
-# fails with HTTP 403. Declared as ARG so the secret stays out of the image.
+# fails with HTTP 403. Provided via a BuildKit secret mount (see the mise block
+# above); the ARG is only the local-build fallback and is left empty in CI so the
+# published image carries no token.
 ARG GITHUB_TOKEN=""
 USER igou
-RUN set -eux; \
+RUN --mount=type=secret,id=github_token set -eux; \
     ARCH_RAW=$(uname -m); \
     case "$ARCH_RAW" in \
       x86_64)  ARCH="x64";   EXPECTED_SHA="${OPENCODE_SHA256_X64}" ;; \
@@ -376,8 +385,9 @@ RUN set -eux; \
     # Release-age gate: fetch the release's published_at from the GitHub API.
     # Authenticated when GITHUB_TOKEN is set (5000/hr), else unauthenticated (60/hr).
     META_URL="https://api.github.com/repos/anomalyco/opencode/releases/tags/${OPENCODE_VERSION}"; \
+    GH_TOKEN_RESOLVED="$(cat /run/secrets/github_token 2>/dev/null || printf '%s' "${GITHUB_TOKEN}")"; \
     AUTH_HEADER=""; \
-    [ -n "${GITHUB_TOKEN}" ] && AUTH_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"; \
+    [ -n "$GH_TOKEN_RESOLVED" ] && AUTH_HEADER="Authorization: Bearer $GH_TOKEN_RESOLVED"; \
     PUBLISHED_AT=$(curl -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} "$META_URL" | jq -r '.published_at'); \
     if [ -z "$PUBLISHED_AT" ] || [ "$PUBLISHED_AT" = "null" ]; then \
       echo "Failed to fetch published_at for opencode ${OPENCODE_VERSION} from $META_URL" >&2; \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,9 @@ permissions:
   contents: write
   packages: write
 
+env:
+  IMAGE: ghcr.io/igou-io/igou-devenv
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,18 +24,56 @@ jobs:
       - name: Log in to GHCR
         # Direct docker CLI login instead of docker/login-action because
         # codeload.github.com is consistently failing to serve that action's
-        # tarball ("An action could not be found at the URI ..."), affecting
-        # both v4.1.0 and v4.2.0 digests. This bypasses codeload entirely.
+        # tarball ("An action could not be found at the URI ..."). This bypasses
+        # codeload entirely.
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build and test devcontainer
-        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Build with buildx directly (not devcontainers/ci) so GITHUB_TOKEN can be
+      # passed as a BuildKit *secret* rather than a build ARG. Build args leak
+      # into the published image's history; secrets never touch a layer. The
+      # Dockerfile reads it from /run/secrets/github_token during mise/opencode.
+      - name: Build image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          push: ${{ github.event_name != 'pull_request' && 'always' || 'never' }}
-          imageName: ghcr.io/igou-io/igou-devenv
-          runCmd: /workspace/igou-devenv/tests/run-all.sh
+        run: |
+          docker buildx build \
+            --file .devcontainer/Dockerfile \
+            --secret id=github_token,env=GITHUB_TOKEN \
+            --cache-from type=registry,ref=${IMAGE}:latest \
+            --cache-to type=inline \
+            --tag ${IMAGE}:latest \
+            --load \
+            .
+
+      # Run the full suite inside the freshly built image. This mirrors what
+      # devcontainers/ci did via `devcontainer up` + exec: the devcontainer
+      # runArgs (privileged, host network, /dev passthrough for KVM/fuse), the
+      # workspace bind-mounted at /workspace/igou-devenv, and the suite running
+      # as the non-root `igou` user. We chown the bind-mounted workspace to igou
+      # (devcontainers/ci handled this via UID remap) and set PATH/HOME/CI
+      # explicitly because CI builds don't run post-create's .bashrc copy.
+      - name: Test
+        run: |
+          docker run --rm \
+            --privileged --network=host \
+            --device=/dev/fuse --device=/dev/net/tun \
+            -v /dev:/dev \
+            -v "$PWD:/workspace/igou-devenv" \
+            -w /workspace \
+            "${IMAGE}:latest" \
+            bash -c 'chown -R igou:igou /workspace/igou-devenv && \
+              exec runuser -u igou -- env \
+                HOME=/home/igou \
+                CI=true \
+                PATH=/home/igou/.local/bin:/home/igou/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+                bash /workspace/igou-devenv/tests/run-all.sh'
+
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: docker push ${IMAGE}:latest
 
       - name: Generate devcontainer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,9 +67,8 @@ jobs:
             bash -c 'chown -R igou:igou /workspace/igou-devenv && \
               exec runuser -u igou -- env \
                 HOME=/home/igou \
-                CI=true \
                 PATH=/home/igou/.local/bin:/home/igou/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-                bash /workspace/igou-devenv/tests/run-all.sh'
+                /workspace/igou-devenv/tests/ci-run.sh'
 
       - name: Push image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,15 +56,21 @@ jobs:
       # (devcontainers/ci handled this via UID remap) and set PATH/HOME/CI
       # explicitly because CI builds don't run post-create's .bashrc copy.
       - name: Test
+        # Mount the checkout read-only and copy it to a container-local,
+        # igou-owned path. The suite writes inside the repo (test-run-scripts
+        # creates temp env files), so it needs a writable, igou-owned tree —
+        # but chowning the bind-mounted checkout would change the host
+        # workspace's ownership and break later steps (e.g. the SBOM writer).
         run: |
           docker run --rm \
             --privileged --network=host \
             --device=/dev/fuse --device=/dev/net/tun \
             -v /dev:/dev \
-            -v "$PWD:/workspace/igou-devenv" \
+            -v "$PWD:/src:ro" \
             -w /workspace \
             "${IMAGE}:latest" \
-            bash -c 'chown -R igou:igou /workspace/igou-devenv && \
+            bash -c 'cp -a /src /workspace/igou-devenv && \
+              chown -R igou:igou /workspace/igou-devenv && \
               exec runuser -u igou -- env \
                 HOME=/home/igou \
                 PATH=/home/igou/.local/bin:/home/igou/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/tests/ci-run.sh
+++ b/tests/ci-run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# CI test entrypoint, run inside the freshly built image by
+# .github/workflows/build.yaml (which builds with `docker buildx` so it can pass
+# GITHUB_TOKEN as a BuildKit secret instead of a leaky build ARG). Runs as the
+# non-root `igou` user.
+#
+# The build workflow drives the image directly rather than through the
+# devcontainer lifecycle, so we start the dbus + libvirt daemons that
+# post-start.sh normally brings up — test-qemu checks their sockets.
+# post-start.sh exits early when CI is set, so it runs here with CI unset; the
+# suite then runs with CI set so it skips test-env, which needs an interactive
+# login shell + .bashrc that CI does not configure.
+set -uo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+"$DIR/../.devcontainer/post-start.sh" || echo "==> post-start.sh exited $? (continuing to tests)"
+
+CI=1 exec "$DIR/run-all.sh"


### PR DESCRIPTION
## Problem
The published image (`ghcr.io/igou-io/igou-devenv`) leaked the CI `GITHUB_TOKEN` into its **layer history** — every `created_by` recorded `GITHUB_TOKEN=ghs_…` (an Actions token scoped `contents:write` + `packages:write`). Cause: `devcontainer.json` passes it as a **build ARG** and the Dockerfile expands `${GITHUB_TOKEN}` in `RUN` steps; build args leak into history, secrets don't.

The tokens are ephemeral (revoked at job end) so there's no *live* credential to steal, but it trips secret scanners, is a latent footgun, and blocks making the package public.

## Fix
- **Dockerfile** — the `mise install` and `opencode` `RUN` steps read the token from `--mount=type=secret,id=github_token` (never written to a layer). The `ARG GITHUB_TOKEN` remains only as a fallback for local `make`/Cursor builds (which can't pass a build secret via `devcontainer.json`); a token in a never-published local image is acceptable. **CI leaves the ARG empty and supplies the secret**, so the published image is token-free.
- **build.yaml** — builds via `docker buildx build --secret` (the `devcontainers/ci` action can't pass BuildKit secrets). The test suite runs inside the freshly built image with the same runArgs the action used (`--privileged`, host network, `/dev` passthrough for KVM/fuse), as the non-root `igou` user; image pushed only on non-PR.

`devcontainer.json` and the `Makefile` are **unchanged** — local/Cursor builds keep working via the ARG fallback.

## Verify after merge
```
docker buildx imagetools inspect ghcr.io/igou-io/igou-devenv:latest --format '{{json .Image}}' | grep -i github_token   # → no matches
```

Once green + merged, the image can safely be made public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)