### PR TITLE
docs: add `make run` to pull-and-run code-server from the public image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SSH_MOUNT = $(shell [ -S "$$SSH_AUTH_SOCK" ] && echo '--mount type=bind,source=$
 
 .DEFAULT_GOAL := help
 
-.PHONY: build up down restart exec shell test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock release release-dry-run release-prepare release-watch
+.PHONY: build up down restart exec shell run test test-all test-tools test-podman test-env test-mise test-mise-lockfile test-qemu clean rebuild help renovate-validate renovate-dry-run sbom sbom-devcontainer e2e opencode-build mise-lock release release-dry-run release-prepare release-watch
 
 
 ## Build the devcontainer image (with cache)
@@ -50,6 +50,35 @@ shell:
 ## Run a command in the running devcontainer (usage: make exec CMD="kubectl version")
 exec:
 	$(DEVCONTAINER) exec --workspace-folder $(WORKSPACE) $(CMD)
+
+# ---------------------------------------------------------------------------
+# Run via the published image — pull-and-run code-server, no build, no login.
+# The GHCR image is public, so `podman` pulls it anonymously. Opens DIR (default
+# the current directory) in a browser IDE on PORT. Ctrl-C stops it (--rm).
+#   make run                                  # current dir, :latest, port 8080
+#   make run DIR=~/code TAG=2026.06.15-2 PORT=8443 PASSWORD=hunter2
+# `--userns=keep-id:uid=1000,gid=1000` maps your host user to the image's `igou`
+# (uid 1000) so the mounted directory is writable. Ephemeral: code-server config
+# and extensions are not persisted (use `make up` for the full, persistent
+# devcontainer). PASSWORD is generated and printed if not supplied.
+# ---------------------------------------------------------------------------
+IMAGE    ?= ghcr.io/igou-io/igou-devenv
+TAG      ?= latest
+PORT     ?= 8080
+DIR      ?= $(CURDIR)
+PASSWORD ?=
+
+## Pull and run code-server from the published image (no build; usage: make run [DIR=~/code] [TAG=2026.06.15-2] [PORT=8443])
+run:
+	@pw='$(PASSWORD)'; [ -n "$$pw" ] || pw="$$(head -c 18 /dev/urandom | base64)"; \
+	echo ">>> code-server → http://localhost:$(PORT)   (password: $$pw)"; \
+	podman run --rm -it --name igou-devenv-run \
+		--userns=keep-id:uid=1000,gid=1000 \
+		-e HOME=/home/igou -e PASSWORD="$$pw" \
+		-p $(PORT):8080 \
+		-v "$(DIR):/workspace:Z" \
+		$(IMAGE):$(TAG) \
+		code-server --bind-addr 0.0.0.0:8080 /workspace
 
 ## Run all tests (tools, podman, env, mise lockfile freshness + audit)
 test-all: test-tools test-podman test-env test-mise-lockfile test-mise test-qemu

--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ make down    # stop and remove the container
 The Makefile automatically forwards your SSH agent if `SSH_AUTH_SOCK` is set
 and the socket exists.
 
+`make up` is not a from-scratch build: `devcontainer.json` sets
+`cacheFrom: ghcr.io/igou-io/igou-devenv`, so it pulls the published image and
+reuses its layers. The image is **public**, so no `docker login` is needed.
+
+### Run via pull (no build)
+
+To skip building entirely and just get the browser IDE on a folder, pull and run
+the published image directly. The package is public, so this needs **no login**:
+
+```bash
+make run                 # opens the current dir in code-server at http://localhost:8080
+make run DIR=~/code      # open a different folder
+make run TAG=2026.06.15-2 PORT=8443 PASSWORD=hunter2   # pin a release, port, password
+```
+
+`make run` prints a generated password and starts code-server in the foreground
+(Ctrl-C to stop; the container is removed on exit). It's the raw equivalent of:
+
+```bash
+podman run --rm -it --userns=keep-id:uid=1000,gid=1000 \
+  -e HOME=/home/igou -e PASSWORD=hunter2 \
+  -p 8080:8080 -v "$PWD:/workspace:Z" \
+  ghcr.io/igou-io/igou-devenv:2026.06.15-2 \
+  code-server --bind-addr 0.0.0.0:8080 /workspace
+```
+
+This is a lightweight, **ephemeral** path — code-server settings/extensions and
+the password are not persisted. For the full, persistent environment (always-on
+code-server, SSH agent, 1Password, kubeconfig, podman-in-podman, libvirt) use the
+devcontainer via `make up` or Cursor. Pin a `:YYYY.MM.DD` tag for reproducibility;
+`:latest` tracks the most recent green build on `main`.
+
 ### After First Build
 
 The `post-create.sh` script automatically:


### PR DESCRIPTION
Now that the GHCR package is public, add an easy **no-build, no-login** path to run the browser IDE from the pulled image.

## Added
- **`make run`** — pulls `ghcr.io/igou-io/igou-devenv` and starts code-server on a folder/port:
  ```bash
  make run                       # current dir → http://localhost:8080
  make run DIR=~/code TAG=2026.06.15-2 PORT=8443 PASSWORD=hunter2
  ```
  Foreground (Ctrl-C to stop), `--rm`, generated password printed. `--userns=keep-id:uid=1000,gid=1000` maps the host user to the image's `igou` so the mount is writable. Ephemeral (no persisted config) — `make up` remains the full, persistent devcontainer.
- **README** — a "Run via pull (no build)" section (with the raw `podman run` equivalent), and a note that `make up` already reuses the published image via `cacheFrom` and needs no `docker login`.

## Verified
Against the public image: anonymous pull works; code-server starts as `igou` with `PASSWORD` auth and serves the login page; mounted workspace is visible. (`make -n run` expansion checked; target shows in `make help`.)

No Dockerfile/CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)