### PR TITLE
fix(use): scope kubeconfig EXIT cleanup to creating shell (#98)

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -172,11 +172,20 @@ PROMPT_COMMAND="_fix_ssh_auth_sock${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 # Use unuse() to remove an environment's variables.
 _use_sanitize() { echo "${1//-/_}"; }
 
-# Clean up all temp kubeconfig files on shell exit
+# Clean up temp kubeconfig files on shell exit — but only for files this shell
+# created. The trap is registered in every interactive shell and _USE_TMPKUBE_*
+# vars are exported, so a short-lived child interactive shell would otherwise
+# delete a parent/sibling shell's still-in-use kubeconfig (issue #98). Each entry
+# records its creator's $BASHPID in _USE_TMPKUBE_OWNER_<name>; only the creating
+# shell deletes the file.
 _use_cleanup_all() {
-    local varname
+    local varname name owner_var
     while IFS='=' read -r varname _; do
-        [[ "$varname" == _USE_TMPKUBE_* ]] && rm -f "${!varname}"
+        [[ "$varname" == _USE_TMPKUBE_* ]] || continue
+        [[ "$varname" == _USE_TMPKUBE_OWNER_* ]] && continue
+        name="${varname#_USE_TMPKUBE_}"
+        owner_var="_USE_TMPKUBE_OWNER_${name}"
+        [ "${!owner_var:-}" = "$BASHPID" ] && rm -f "${!varname}"
     done < <(env)
 }
 trap _use_cleanup_all EXIT
@@ -278,6 +287,8 @@ KUBECFG
         export KUBECONFIG="$tmpkube"
         keys+=("KUBECONFIG")
         export "$tmpvar=$tmpkube"
+        # Record the creating shell so only it deletes the file on EXIT (issue #98)
+        export "_USE_TMPKUBE_OWNER_${safe_name}=$BASHPID"
     fi
 
     # Track which keys this env set (for unuse)
@@ -331,6 +342,7 @@ unuse() {
         rm -f "${!tmpvar}"
         unset "$tmpvar"
     fi
+    unset "_USE_TMPKUBE_OWNER_${safe_name}"
 
     # Update OP_ENV_LIST: remove this env
     local new_list="" env_name

--- a/tests/test-env.sh
+++ b/tests/test-env.sh
@@ -420,6 +420,51 @@ else
 fi
 
 # =========================================================================
+#  Tests: EXIT-trap cleanup is owner-scoped (issue #98)
+# =========================================================================
+# A short-lived child interactive shell inherits exported _USE_TMPKUBE_* vars.
+# It must NOT delete a kubeconfig created by a different (parent/sibling) shell.
+# _use_cleanup_all deletes only files whose _USE_TMPKUBE_OWNER_<name> == $BASHPID.
+echo ""
+echo "==> Testing owner-scoped EXIT cleanup (issue #98)..."
+
+unset KUBECONFIG OP_ENV OP_ENV_LIST 2>/dev/null || true
+
+use with-kubeconfig > /dev/null 2>&1
+_owned_kube="$KUBECONFIG"
+
+# Sanity: owner var was recorded and points at this shell.
+if [ "${_USE_TMPKUBE_OWNER_with_kubeconfig:-}" = "$BASHPID" ]; then
+    ok "owner PID recorded for created kubeconfig"
+else
+    fail "owner PID recorded (got: ${_USE_TMPKUBE_OWNER_with_kubeconfig:-unset}, BASHPID=$BASHPID)"
+fi
+
+# Simulate a child interactive shell exiting: same inherited env, different
+# BASHPID. _use_cleanup_all must NOT delete the parent's file.
+( _use_cleanup_all ) # subshell → distinct $BASHPID, inherits exported vars
+if [ -f "$_owned_kube" ]; then
+    ok "child-shell EXIT does not delete sibling kubeconfig"
+else
+    fail "child-shell EXIT deleted sibling kubeconfig ($_owned_kube)"
+fi
+# KUBECONFIG still usable in this (owner) shell.
+if [ -f "$KUBECONFIG" ] && grep -q "apiVersion" "$KUBECONFIG" 2>/dev/null; then
+    ok "owner shell kubeconfig still valid after child exit"
+else
+    fail "owner shell kubeconfig still valid after child exit"
+fi
+
+# The owning shell's own cleanup DOES delete the file.
+_use_cleanup_all
+if [ ! -f "$_owned_kube" ]; then
+    ok "owner-shell EXIT deletes its own kubeconfig"
+else
+    fail "owner-shell EXIT deletes its own kubeconfig ($_owned_kube)"
+fi
+unuse with-kubeconfig > /dev/null 2>&1
+
+# =========================================================================
 #  Tests: k8s-unset
 # =========================================================================
 echo ""


### PR DESCRIPTION
## Summary

Fixes #98 — `use()`'s `EXIT` trap deleted temp kubeconfigs that belonged to other shells.

- `_use_cleanup_all` ran in every interactive shell and `rm -f`'d any file referenced by an inherited, exported `_USE_TMPKUBE_*` var. A short-lived child interactive shell (e.g. an agent TUI launcher) therefore wiped the parent shell's still-in-use kubeconfig, leaving `KUBECONFIG` pointing at a missing file → `oc`/`kubectl` fail with "Missing or incomplete configuration info".
- Fix (issue's recommended approach 1): `use()` records the creating shell's `$BASHPID` in `_USE_TMPKUBE_OWNER_<name>`; `_use_cleanup_all` only deletes when that owner equals the current `$BASHPID`. Child subshells inherit the owner PID but have a different `$BASHPID`, so they no longer delete a sibling/parent's file. `unuse()` unsets the owner var; re-`use()` refreshes it.

## Test plan

- [x] `shellcheck dotfiles/.bashrc tests/test-env.sh` — no new warnings
- [x] `make rebuild` + `make test` — env suite 45/45 (incl. new owner-scoped cleanup regression test), all suites 0 failed
- New tests assert: owner PID recorded, a child-shell cleanup does **not** delete a sibling kubeconfig, the owner shell's config stays valid, and the owning shell's own EXIT still cleans up.

Deferred: approach 4 (cleanup only on explicit `unuse` / activating-shell exit) as a possible follow-up.

Made with [Cursor](https://cursor.com)