### PR TITLE
ci: resubmit SBOM to dependency graph, automerge mise lock maintenance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,12 +87,10 @@ jobs:
           artifact-name: devcontainer-sbom
           output-file: devcontainer.spdx.json
           format: spdx-json
-          # Keep the SBOM as a workflow artifact, but do NOT submit it to the
-          # GitHub dependency graph. The image bundles many third-party Go/npm
-          # CLIs (podman, buildah, kubectl, argocd, code-server, ...); submitting
-          # their embedded module SBOMs floods Dependabot with hundreds of CVE
-          # alerts for upstream binaries we don't build and can't patch here.
-          # Those are remediated by tool-version bumps via Renovate + mise.toml,
-          # not by this repo, so the alerts are non-actionable noise that buries
-          # any real signal. See git history / PR for the investigation.
-          dependency-snapshot: false
+          # Submit the SBOM to the GitHub dependency graph so it always
+          # reflects the image currently on main (the action only submits on
+          # push, not on PRs). This re-enables Dependabot alerts for embedded
+          # modules in bundled Go/npm CLIs (see #84 for the earlier opt-out);
+          # accepted trade-off: alerts against /opt/mise/installs/... paths are
+          # remediated by Renovate tool bumps, not by patches in this repo.
+          dependency-snapshot: true

--- a/.github/workflows/mise-lockfile-check.yaml
+++ b/.github/workflows/mise-lockfile-check.yaml
@@ -16,6 +16,11 @@ on:
       - mise.toml
       - mise.lock
       - .github/workflows/mise-lockfile-check.yaml
+      # The check pins its mise container to the Dockerfile's MISE_VERSION and
+      # mounts the vendored aqua-registry, so bumps to either can invalidate
+      # lockfile semantics and must re-run the check.
+      - .devcontainer/Dockerfile
+      - aqua-registry/**
 
 permissions:
   contents: read

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,12 @@
       "automerge": false
     },
     {
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "description": "Lock-file-maintenance PRs only refresh mise.lock (no mise.toml bump), so release-prepare never touches them; they are safe to automerge behind the required build check.",
+      "automerge": true
+    },
+    {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["jdx/mise"],
       "groupName": "mise itself (trust anchor)"


### PR DESCRIPTION
Review of the mise-lock CI strategy plus the SBOM/dependency-graph flow.

- **Revert #84's `dependency-snapshot` opt-out** — submit the image SBOM to the GitHub dependency graph on pushes to main. The pre-#84 snapshot was never purged: the graph still held 3,315 Go / 513 npm / 573 rpm packages from an old image, with 63 open Dependabot alerts against paths like `/opt/mise/installs/helm/4.2.0/` that are no longer shipped. The first submission replaces that stale snapshot (same correlator). Embedded-module alerts returning is the accepted trade-off; they remediate via Renovate tool bumps.
- **renovate.json: automerge mise `lockFileMaintenance` PRs** — they only refresh `mise.lock`, sit behind the required `build` check, and `release-prepare` never handles their branch, so they were manual-merge only (#97, #105).
- **mise-lockfile-check: widen trigger paths** — the check pins its mise container to the Dockerfile's `MISE_VERSION` and mounts `aqua-registry/`, so PRs bumping either now re-run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPAnihxQCKZyYfBhzaHUMf