### PR TITLE
ci: harden release immutability and bind SBOMs to digests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,17 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
+
+# Serialize builds per ref: two near-simultaneous pushes to main would race
+# on `docker push :latest` with last-writer-wins, letting an older commit's
+# image overwrite a newer one. GitHub keeps at most one running + one pending
+# run per group and replaces the pending run with the newest, so :latest
+# always converges on the most recent commit.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/igou-io/igou-devenv
@@ -44,6 +55,8 @@ jobs:
             --secret id=github_token,env=GITHUB_TOKEN \
             --cache-from type=registry,ref=${IMAGE}:latest \
             --cache-to type=inline \
+            --label org.opencontainers.image.revision=${{ github.sha }} \
+            --label org.opencontainers.image.source=https://github.com/${{ github.repository }} \
             --tag ${IMAGE}:latest \
             --load \
             .
@@ -77,20 +90,64 @@ jobs:
                 /workspace/igou-devenv/tests/ci-run.sh'
 
       - name: Push image
+        id: push
         if: github.event_name != 'pull_request'
-        run: docker push ${IMAGE}:latest
+        run: |
+          docker push ${IMAGE}:latest
+          digest=$(docker buildx imagetools inspect ${IMAGE}:latest --format '{{.Manifest.Digest}}')
+          [ -n "$digest" ] || { echo "::error::could not resolve pushed digest"; exit 1; }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Pushed \`${IMAGE}@${digest}\` (revision ${{ github.sha }})" >> "$GITHUB_STEP_SUMMARY"
+
+      # Scan the exact pushed digest so the SBOM is bound to the artifact
+      # consumers pull, not a mutable tag. PR builds are never pushed, so they
+      # scan the just-built image in the local daemon instead (the explicit
+      # :latest tag keeps syft's daemon-first resolution from silently falling
+      # back to the stale remote image).
+      - name: Resolve SBOM image reference
+        id: sbomref
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "ref=${IMAGE}@${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Generate devcontainer SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ghcr.io/igou-io/igou-devenv
+          image: ${{ steps.sbomref.outputs.ref }}
           artifact-name: devcontainer-sbom
           output-file: devcontainer.spdx.json
           format: spdx-json
           # Submit the SBOM to the GitHub dependency graph so it always
-          # reflects the image currently on main (the action only submits on
-          # push, not on PRs). This re-enables Dependabot alerts for embedded
+          # reflects the image currently on main. The action itself has no
+          # event gating (it would submit on PRs too, and fork PRs' read-only
+          # tokens would 403), so gate the submission here to non-PR events;
+          # the weekly scheduled rebuild submits against main and keeps the
+          # graph fresh. This re-enables Dependabot alerts for embedded
           # modules in bundled Go/npm CLIs (see #84 for the earlier opt-out);
           # accepted trade-off: alerts against /opt/mise/installs/... paths are
           # remediated by Renovate tool bumps, not by patches in this repo.
-          dependency-snapshot: true
+          dependency-snapshot: ${{ github.event_name != 'pull_request' }}
+
+      # Keyless (OIDC) attestations bound to the pushed digest: build
+      # provenance (which workflow/commit produced the image) and the SBOM
+      # generated above. Verifiable with
+      # `gh attestation verify oci://ghcr.io/igou-io/igou-devenv:latest --owner igou-io`.
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/igou-io/igou-devenv
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/igou-io/igou-devenv
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: devcontainer.spdx.json
+          push-to-registry: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ on:
         type: string
         default: ""
       force:
-        description: "Promote even if the tag exists or main hasn't advanced (for manual test runs)"
+        description: "Promote even if main hasn't advanced or the image revision doesn't match HEAD (for manual test runs). Cannot overwrite an existing tag — released tags are immutable; pick a new version instead."
         type: boolean
         default: false
 
@@ -54,13 +54,19 @@ jobs:
           VERSION="${{ inputs.version }}"
           if [ -z "$VERSION" ]; then VERSION="$(date -u +%Y.%m.%d)"; fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [ "${{ inputs.force }}" = "true" ]; then
-            echo "force=true — promoting v$VERSION regardless of guards." | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
+          # Released tags are immutable: the tag-exists guard is NOT
+          # force-bypassable. Before this, force + an existing version would
+          # repoint the already-published image tag to a new digest (the
+          # promote step runs before the git-tag step fails). A tag ruleset
+          # protects refs/tags/v* on the git side; this guard is the
+          # registry-side equivalent.
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Skipped: tag v$VERSION already exists." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "Skipped: tag v$VERSION already exists (immutable — use a new version)." | tee -a "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "force=true — promoting v$VERSION even if main hasn't advanced." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           last="$(git tag --list 'v*' --sort=-creatordate | head -1)"
           if [ -n "$last" ] && [ -z "$(git log "$last"..HEAD --oneline)" ]; then
@@ -82,6 +88,33 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "Promoting ghcr.io/igou-io/igou-devenv@$digest -> :${{ steps.plan.outputs.version }}" | tee -a "$GITHUB_STEP_SUMMARY"
 
+      # :latest is a floating tag: the 06:30 release-prepare merge kicks off a
+      # ~10 min build, so an 08:00 release could promote last week's digest
+      # while the release notes claim this week's merges. The image's
+      # org.opencontainers.image.revision label (stamped by build.yaml) is the
+      # ground truth for what :latest was built from — require it to match
+      # main HEAD unless force is set.
+      - name: Assert :latest was built from main HEAD
+        if: steps.plan.outputs.proceed == 'true'
+        run: |
+          revision=$(docker buildx imagetools inspect \
+            ghcr.io/igou-io/igou-devenv@${{ steps.img.outputs.digest }} \
+            --format '{{index .Image.Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)
+          head=$(git rev-parse HEAD)
+          if [ -z "$revision" ] || [ "$revision" = "<no value>" ]; then
+            echo "::warning:::latest has no revision label (built before labels were added); skipping HEAD check."
+            exit 0
+          fi
+          echo "revision=$revision head=$head" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$revision" != "$head" ]; then
+            if [ "${{ inputs.force }}" = "true" ]; then
+              echo "::warning:::latest revision $revision != main HEAD $head — proceeding due to force=true."
+            else
+              echo "::error:::latest revision $revision != main HEAD $head — the HEAD build likely hasn't pushed yet. Re-run once it finishes, or use force to promote the older tested image."
+              exit 1
+            fi
+          fi
+
       - name: Promote the digest to the CalVer tag
         if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
         run: |
@@ -89,11 +122,27 @@ jobs:
             --tag ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }} \
             ghcr.io/igou-io/igou-devenv@${{ steps.img.outputs.digest }}
 
+      # imagetools create wraps the promoted manifest in a new manifest list,
+      # so the :VERSION tag's digest differs from the :latest digest it came
+      # from. Resolve the digest consumers will actually pull so it can be
+      # recorded in the release and used for the SBOM scan.
+      - name: Resolve the released tag digest
+        id: rel
+        if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }} \
+            --format '{{.Manifest.Digest}}')
+          [ -n "$digest" ] || { echo "::error::could not resolve released tag digest"; exit 1; }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Generate SBOM
         if: steps.plan.outputs.proceed == 'true' && inputs.dry_run != true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          image: ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}
+          # Scan the immutable digest, not the tag, so the SBOM is bound to
+          # the exact released artifact.
+          image: ghcr.io/igou-io/igou-devenv@${{ steps.rel.outputs.digest }}
           artifact-name: devcontainer-sbom-${{ steps.plan.outputs.version }}
           output-file: devcontainer.spdx.json
           format: spdx-json
@@ -105,10 +154,21 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.plan.outputs.version }}" -m "v${{ steps.plan.outputs.version }}"
+          git tag -a "v${{ steps.plan.outputs.version }}" -m "v${{ steps.plan.outputs.version }}
+
+          image: ghcr.io/igou-io/igou-devenv@${{ steps.rel.outputs.digest }}"
           git push origin "v${{ steps.plan.outputs.version }}"
+          {
+            echo "ghcr.io/igou-io/igou-devenv:${{ steps.plan.outputs.version }}"
+            echo "pull-by-digest: ghcr.io/igou-io/igou-devenv@${{ steps.rel.outputs.digest }}"
+            echo "promoted-from (:latest manifest): ${{ steps.img.outputs.digest }}"
+          } > image-digest.txt
           gh release create "v${{ steps.plan.outputs.version }}" \
             --repo igou-io/igou-devenv \
             --title "v${{ steps.plan.outputs.version }}" \
             --generate-notes \
-            devcontainer.spdx.json
+            --notes "$(printf '**Image:** \`ghcr.io/igou-io/igou-devenv:%s\`\n**Digest:** \`%s\` (pull-by-digest; wraps tested :latest manifest \`%s\`)\n\n---\n' \
+              "${{ steps.plan.outputs.version }}" \
+              "${{ steps.rel.outputs.digest }}" \
+              "${{ steps.img.outputs.digest }}")" \
+            devcontainer.spdx.json image-digest.txt


### PR DESCRIPTION
Implements the prioritized findings from the immutable-release and SBOM reviews.

**Repo-side (already applied via API, not in this diff):** tag ruleset `release tags immutable` (id 18472912) on `refs/tags/v*` — deletion, non-fast-forward, and update all blocked, no bypass actors. Tag *creation* stays open so the release workflow is unaffected.

**build.yaml**
- `concurrency` group per ref — closes the last-writer-wins race on `:latest` between overlapping main builds.
- `org.opencontainers.image.revision`/`source` labels — digest→commit traceability, and the ground truth for the new release-time HEAD assertion.
- The pushed digest is captured and the SBOM is scanned from `@digest` (PR builds keep scanning the local just-built image; the explicit tag prevents syft silently falling back to remote `:latest`).
- `dependency-snapshot` gated to non-PR events — the pinned sbom-action has no event gating of its own; same-repo PRs submitted noise and fork PRs' read-only tokens would 403 the build.
- Keyless attestations bound to the pushed digest: `actions/attest-build-provenance` + `actions/attest-sbom`, pushed to GHCR and the attestations API. Verify with `gh attestation verify oci://ghcr.io/igou-io/igou-devenv:latest --owner igou-io`.

**release.yaml**
- The tag-exists guard is no longer bypassed by `force` — previously `force` + an existing version repointed the published image tag to a new digest before the git-tag step failed. Released tags are now immutable on both the git and registry side.
- New assertion: `:latest`'s revision label must equal main HEAD before promotion (warning-only under `force`, and skipped for pre-label images) — closes the window where the 08:00 release promotes last week's digest while the notes claim this week's merges.
- The released tag's manifest-list digest (what consumers actually pull) is resolved after promotion; the release SBOM scans that digest, and the digest + tested `:latest` manifest digest are recorded in the release body, an `image-digest.txt` asset, and the annotated tag message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPAnihxQCKZyYfBhzaHUMf