### PR TITLE
fix(ci): attest SBOM by file provenance; grant artifact-metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 # Serialize builds per ref: two near-simultaneous pushes to main would race
 # on `docker push :latest` with last-writer-wins, letting an older commit's
@@ -143,11 +144,14 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-      - name: Attest SBOM
+      # The SPDX SBOM (~25 MB) exceeds attest-sbom's 16 MiB predicate limit
+      # (and that action is deprecated), so rather than embedding the SBOM in
+      # an attestation, attest provenance over the SBOM *file*: a signed
+      # statement binding the SBOM's sha256 to this workflow run and commit.
+      # Verify a downloaded copy with
+      # `gh attestation verify devcontainer.spdx.json --owner igou-io`.
+      - name: Attest SBOM file provenance
         if: github.event_name != 'pull_request'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-name: ghcr.io/igou-io/igou-devenv
-          subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: devcontainer.spdx.json
-          push-to-registry: true
+          subject-path: devcontainer.spdx.json


### PR DESCRIPTION
Fixes the post-#109 main build failure: `actions/attest-sbom` caps the embedded predicate at 16 MiB and the SPDX SBOM is ~25 MB (the action is also deprecated). Replaces it with `actions/attest-build-provenance` over the SBOM file — signs the SBOM's sha256, binding it to the workflow run and commit, no size ceiling. Verify with `gh attestation verify devcontainer.spdx.json --owner igou-io`. Also grants `artifact-metadata: write`, which both attest steps warned was missing for storage records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPAnihxQCKZyYfBhzaHUMf