### PR TITLE
fix(rk8s): read rk8s kubeconfig from lab_rk8s (gap-1)

### DIFF
--- a/envs/rk8s.env
+++ b/envs/rk8s.env
@@ -1,1 +1,1 @@
-KUBECONFIG_DATA=op://claude/rk8s-kubeconfig/kubeconfig
+KUBECONFIG_DATA=op://lab_rk8s/rk8s-kubeconfig/kubeconfig


### PR DESCRIPTION
Repoints `envs/rk8s.env` (`use rk8s`) from `op://claude/rk8s-kubeconfig` → `op://lab_rk8s/rk8s-kubeconfig`. The kubeconfig moved to lab_rk8s so the aap Connect token can publish it (claude was read-only for aap); vscode has lab_rk8s RW so `use rk8s` still resolves. Companion igou-inventory#137 + igou-ansible#325; item pre-copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)