### PR TITLE
feat(mise): add rustfs-cli (rc) via http backend

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -141,14 +141,6 @@ url = "https://get.helm.sh/helm-v4.2.2-linux-amd64.tar.gz"
 version = "4.123.0"
 backend = "http:code-server"
 
-[tools."http:code-server"."platforms.linux-x64"]
-checksum = "blake3:5ccbf2bb252e1ba2dcba24e4a7ab4c14586feca77dd69dc09c884757d6561326"
-url = "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-amd64.tar.gz"
-
-[[tools."http:code-server"]]
-version = "4.123.0"
-backend = "http:code-server"
-
 [tools."http:code-server".options]
 strip_components = "1"
 
@@ -156,15 +148,8 @@ strip_components = "1"
 url = "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-arm64.tar.gz"
 
 [tools."http:code-server"."platforms.linux-x64"]
+checksum = "blake3:5ccbf2bb252e1ba2dcba24e4a7ab4c14586feca77dd69dc09c884757d6561326"
 url = "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-amd64.tar.gz"
-
-[[tools."http:kube-burner"]]
-version = "2.6.1"
-backend = "http:kube-burner"
-
-[tools."http:kube-burner"."platforms.linux-x64"]
-checksum = "blake3:c515fc3bada5a01a6496ae358bfbeed52cc882409e0b01964caf40e2fe2b2454"
-url = "https://github.com/cloud-bulldozer/kube-burner/releases/download/v2.6.1/kube-burner-V2.6.1-linux-x86_64.tar.gz"
 
 [[tools."http:kube-burner"]]
 version = "2.6.1"
@@ -177,15 +162,8 @@ strip_components = "0"
 url = "https://github.com/cloud-bulldozer/kube-burner/releases/download/v2.6.1/kube-burner-V2.6.1-linux-arm64.tar.gz"
 
 [tools."http:kube-burner"."platforms.linux-x64"]
+checksum = "blake3:c515fc3bada5a01a6496ae358bfbeed52cc882409e0b01964caf40e2fe2b2454"
 url = "https://github.com/cloud-bulldozer/kube-burner/releases/download/v2.6.1/kube-burner-V2.6.1-linux-x86_64.tar.gz"
-
-[[tools."http:kube-burner-ocp"]]
-version = "1.11.11"
-backend = "http:kube-burner-ocp"
-
-[tools."http:kube-burner-ocp"."platforms.linux-x64"]
-checksum = "blake3:429021e6105e10ce3c3eb23e3d3a5d82be8b5a8553e499dd2e04ac8efe7a3402"
-url = "https://github.com/kube-burner/kube-burner-ocp/releases/download/v1.11.11/kube-burner-ocp-V1.11.11-linux-x86_64.tar.gz"
 
 [[tools."http:kube-burner-ocp"]]
 version = "1.11.11"
@@ -198,6 +176,7 @@ strip_components = "0"
 url = "https://github.com/kube-burner/kube-burner-ocp/releases/download/v1.11.11/kube-burner-ocp-V1.11.11-linux-arm64.tar.gz"
 
 [tools."http:kube-burner-ocp"."platforms.linux-x64"]
+checksum = "blake3:429021e6105e10ce3c3eb23e3d3a5d82be8b5a8553e499dd2e04ac8efe7a3402"
 url = "https://github.com/kube-burner/kube-burner-ocp/releases/download/v1.11.11/kube-burner-ocp-V1.11.11-linux-x86_64.tar.gz"
 
 [[tools."http:oc"]]
@@ -210,6 +189,17 @@ url = "https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.21.16
 [tools."http:oc"."platforms.linux-x64"]
 checksum = "blake3:0750313e14f2cc7c62404740e39027c9f0a6f8e2633d1f4a0a5a2cce29c5b870"
 url = "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.21.16/openshift-client-linux.tar.gz"
+
+[[tools."http:rustfs-cli"]]
+version = "0.1.25"
+backend = "http:rustfs-cli"
+
+[tools."http:rustfs-cli"."platforms.linux-arm64"]
+url = "https://github.com/rustfs/cli/releases/download/v0.1.25/rustfs-cli-linux-arm64-gnu-v0.1.25.tar.gz"
+
+[tools."http:rustfs-cli"."platforms.linux-x64"]
+checksum = "blake3:9d79d1a1755544a247efe81f2378b09d26c1bdc7039f9f7fe4fd9c5ea49fd6a7"
+url = "https://github.com/rustfs/cli/releases/download/v0.1.25/rustfs-cli-linux-amd64-gnu-v0.1.25.tar.gz"
 
 [[tools."http:virtctl"]]
 version = "1.8.2"

--- a/mise.toml
+++ b/mise.toml
@@ -155,3 +155,24 @@ bin_path = "bin"
 [tools."http:code-server".platforms]
 linux-x64   = { url = "https://github.com/coder/code-server/releases/download/v{{ version }}/code-server-{{ version }}-linux-amd64.tar.gz", strip_components = 1 }
 linux-arm64 = { url = "https://github.com/coder/code-server/releases/download/v{{ version }}/code-server-{{ version }}-linux-arm64.tar.gz", strip_components = 1 }
+
+# rustfs-cli — the `rc` admin/client CLI for RustFS S3 servers. Only the RustFS
+# *server* (github:rustfs/rustfs) is in aqua-registry; the CLI is not, so it
+# uses the http backend like the other off-registry tools above. Upstream ships
+# per-asset .sha256 + SHA256SUMS but NO GPG signature, SLSA provenance, or
+# gh-attestation (checked 2026-07 against v0.1.25), so the http backend's blake3
+# TOFU pin in mise.lock is the strongest verification available — the same trust
+# floor accepted for virtctl/kube-burner/code-server. The global
+# minimum_release_age = "10d" gate still applies.
+#
+# The gnu (glibc) artifacts match the CentOS Stream 10 devcontainer. The tarball
+# is a flat archive whose single binary is named `rc` (not rustfs-cli), so no
+# strip_components/bin_path is needed and the launch-check binary override in
+# tests/mise-expected-verification.toml points at `rc`.
+# renovate: datasource=github-releases depName=rustfs/cli
+[tools."http:rustfs-cli"]
+version = "0.1.25"
+
+[tools."http:rustfs-cli".platforms]
+linux-x64   = { url = "https://github.com/rustfs/cli/releases/download/v{{ version }}/rustfs-cli-linux-amd64-gnu-v{{ version }}.tar.gz" }
+linux-arm64 = { url = "https://github.com/rustfs/cli/releases/download/v{{ version }}/rustfs-cli-linux-arm64-gnu-v{{ version }}.tar.gz" }

--- a/tests/mise-expected-verification.toml
+++ b/tests/mise-expected-verification.toml
@@ -96,3 +96,10 @@ argocd = "sha256+slsa"
 # http backend's blake3 TOFU pin in mise.lock is the strongest floor available
 # (same as the other http: tools). The launch check runs `code-server --version`.
 "http:code-server" = "blake3"   # binary: code-server
+
+# rustfs-cli (`rc`). Not in aqua-registry; the http backend pins a blake3 TOFU
+# floor in mise.lock. Upstream ships .sha256/SHA256SUMS but no GPG/SLSA/
+# attestation, so blake3 is the strongest available floor (same as the http:
+# tools above). The archive's binary is named `rc`, so the launch check runs
+# `rc --version` via the binary override.
+"http:rustfs-cli" = "blake3"   # binary: rc


### PR DESCRIPTION
## Summary

Adds the RustFS `rc` admin/client CLI to the mise-managed tool set in `igou-devenv`.

- Only the RustFS **server** (`github:rustfs/rustfs`) is in aqua-registry; the **CLI is not**, so it uses the **`http:` backend** like `virtctl`/`oc`/`kube-burner`/`code-server`.
- Pinned **v0.1.25** (13 days old → clears the `minimum_release_age = "10d"` gate).
- Uses the **gnu (glibc)** artifacts to match the CentOS Stream 10 devcontainer.
- The tarball is a flat archive whose single binary is named **`rc`** (not `rustfs-cli`) — no `strip_components`/`bin_path` needed; recorded as the launch-check binary override.

## Verification

Upstream ships per-asset `.sha256` + `SHA256SUMS` but **no GPG signature, SLSA provenance, or gh-attestation** (checked 2026-07 against v0.1.25). The http backend does not consult upstream checksum files, so mise pins a **blake3 TOFU** digest in `mise.lock` — the strongest available floor and the same one already accepted for the other `http:` tools.

## Files changed

- `mise.toml` — new `[tools."http:rustfs-cli"]` block with Renovate annotation + per-platform URLs
- `mise.lock` — regenerated via `make mise-lock` (blake3 x64 pin + arm64 URL)
- `tests/mise-expected-verification.toml` — audit entry `"http:rustfs-cli" = "blake3"   # binary: rc`

## Testing

- `make mise-lock` regenerated the lock cleanly.
- `rc --version` → `rc 0.1.25` (exit 0) — the exact command the launch check runs.
- `tests/test-mise.sh` verification audit: `[OK] http:rustfs-cli verified via blake3` and the launch check passes with `rc` on PATH (as a real image build provides).
- Full `make rebuild && make test` should run in CI, since a host-side rebuild isn't available from inside the devcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193kE4t5KgxsRm8AkTfSRhC