### PR TITLE
fix(env): harden use()/unuse() kubeconfig handling

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -172,6 +172,17 @@ PROMPT_COMMAND="_fix_ssh_auth_sock${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 # Use unuse() to remove an environment's variables.
 _use_sanitize() { echo "${1//-/_}"; }
 
+# Kubeconfig-resolution failure path for use(). Called from inside use(), so it
+# sees use()'s locals ($tmpkube, $keys) via dynamic scoping: report the error,
+# remove the temp file, and roll back the keys already exported so a failed
+# use() doesn't leave a half-active environment.
+_use_kube_fail() {
+    echo "Failed to resolve kubeconfig for ${1}"
+    rm -f "$tmpkube"
+    local k
+    for k in "${keys[@]}"; do unset "$k"; done
+}
+
 # Clean up temp kubeconfig files on shell exit — but only for files this shell
 # created. The trap is registered in every interactive shell and _USE_TMPKUBE_*
 # vars are exported, so a short-lived child interactive shell would otherwise
@@ -212,9 +223,9 @@ use() {
     #   KUBECONFIG_TOKEN + KUBECONFIG_HOST — dynamically build a kubeconfig from token/host
     # Both present is an error.
     local kubeconfig_data_ref kubeconfig_token_ref kubeconfig_host_ref
-    kubeconfig_data_ref=$(grep '^KUBECONFIG_DATA=' "$envfile" | cut -d= -f2)
-    kubeconfig_token_ref=$(grep '^KUBECONFIG_TOKEN=' "$envfile" | cut -d= -f2)
-    kubeconfig_host_ref=$(grep '^KUBECONFIG_HOST=' "$envfile" | cut -d= -f2)
+    kubeconfig_data_ref=$(grep -m1 '^KUBECONFIG_DATA=' "$envfile" | cut -d= -f2-)
+    kubeconfig_token_ref=$(grep -m1 '^KUBECONFIG_TOKEN=' "$envfile" | cut -d= -f2-)
+    kubeconfig_host_ref=$(grep -m1 '^KUBECONFIG_HOST=' "$envfile" | cut -d= -f2-)
 
     if [ -n "$kubeconfig_data_ref" ] && { [ -n "$kubeconfig_token_ref" ] || [ -n "$kubeconfig_host_ref" ]; }; then
         echo "Error: ${1}.env has both KUBECONFIG_DATA and KUBECONFIG_TOKEN/KUBECONFIG_HOST — use one or the other"
@@ -249,20 +260,36 @@ use() {
     fi
 
     if [ -n "$kubeconfig_data_ref" ] || [ -n "$kubeconfig_token_ref" ]; then
-        # Clean up previous temp kubeconfig for this env if re-using
+        # Clean up previous temp kubeconfig for this env if re-using — but only
+        # if this shell created it. An inherited _USE_TMPKUBE_* var points at a
+        # file a parent/sibling shell still uses (issue #98).
         local tmpvar="_USE_TMPKUBE_${safe_name}"
-        [ -n "${!tmpvar:-}" ] && rm -f "${!tmpvar}"
+        local ownervar="_USE_TMPKUBE_OWNER_${safe_name}"
+        if [ -n "${!tmpvar:-}" ] && [ "${!ownervar:-}" = "$BASHPID" ]; then
+            rm -f "${!tmpvar}"
+        fi
         local tmpkube
         tmpkube=$(mktemp /tmp/kubeconfig.XXXXXX)
 
         if [ -n "$kubeconfig_data_ref" ]; then
             # Full kubeconfig from 1Password (base64-encoded)
-            op read "$kubeconfig_data_ref" | base64 -d > "$tmpkube"
+            local kube_b64
+            if ! kube_b64=$(op read "$kubeconfig_data_ref") || \
+               ! echo "$kube_b64" | base64 -d > "$tmpkube"; then
+                _use_kube_fail "$1"
+                return 1
+            fi
         else
             # Build kubeconfig from token + host
             local kube_token kube_host
-            kube_token=$(echo "$kubeconfig_token_ref" | op inject)
-            kube_host=$(echo "$kubeconfig_host_ref" | op inject)
+            if ! kube_token=$(echo "$kubeconfig_token_ref" | op inject) || [ -z "$kube_token" ]; then
+                _use_kube_fail "$1"
+                return 1
+            fi
+            if ! kube_host=$(echo "$kubeconfig_host_ref" | op inject) || [ -z "$kube_host" ]; then
+                _use_kube_fail "$1"
+                return 1
+            fi
             cat > "$tmpkube" << KUBECFG
 apiVersion: v1
 kind: Config
@@ -336,13 +363,16 @@ unuse() {
         unset "$keys_var"
     fi
 
-    # Clean up temp kubeconfig
+    # Clean up temp kubeconfig — delete the file only if this shell created it.
+    # An inherited _USE_TMPKUBE_* var points at a file a parent/sibling shell
+    # still uses (issue #98); still unset this shell's copies of the vars.
     local tmpvar="_USE_TMPKUBE_${safe_name}"
+    local ownervar="_USE_TMPKUBE_OWNER_${safe_name}"
     if [ -n "${!tmpvar:-}" ]; then
-        rm -f "${!tmpvar}"
+        [ "${!ownervar:-}" = "$BASHPID" ] && rm -f "${!tmpvar}"
         unset "$tmpvar"
     fi
-    unset "_USE_TMPKUBE_OWNER_${safe_name}"
+    unset "$ownervar"
 
     # Update OP_ENV_LIST: remove this env
     local new_list="" env_name

--- a/tests/test-env.sh
+++ b/tests/test-env.sh
@@ -99,6 +99,23 @@ CONTROLLER_PASSWORD=op://Homelab/aap/password
 CONTROLLER_USERNAME=op://Homelab/aap/username
 EOF
 
+# Refs that don't exist in the mock secrets — resolution must fail loudly
+cat > "$TESTDIR/envs/bad-kubeconfig.env" << 'EOF'
+KUBECONFIG_DATA=op://Homelab/missing/kubeconfig
+AWS_DEFAULT_REGION=us-east-1
+EOF
+
+cat > "$TESTDIR/envs/bad-token.env" << 'EOF'
+KUBECONFIG_TOKEN=op://Homelab/missing/token
+KUBECONFIG_HOST=op://Homelab/test-cluster/api-host
+EOF
+
+# Plain (non-op://) host value containing '=' — must not be truncated
+cat > "$TESTDIR/envs/equals-host.env" << 'EOF'
+KUBECONFIG_TOKEN=op://Homelab/test-cluster/token
+KUBECONFIG_HOST=https://api.test-cluster.example.com:6443/?scope=admin
+EOF
+
 # Override the envdir used by use() for testing.
 # Redefine use() to point at our test envdir instead of the real one.
 _original_use=$(declare -f use)
@@ -463,6 +480,114 @@ else
     fail "owner-shell EXIT deletes its own kubeconfig ($_owned_kube)"
 fi
 unuse with-kubeconfig > /dev/null 2>&1
+
+# =========================================================================
+#  Tests: use() — kubeconfig resolution failure is detected
+# =========================================================================
+# A failed `op read`/`op inject` must fail the whole use() call: nonzero rc,
+# no KUBECONFIG export, no half-activated env, no leftover temp file.
+echo ""
+echo "==> Testing use() — kubeconfig resolution failure..."
+
+unset KUBECONFIG AWS_DEFAULT_REGION OP_ENV OP_ENV_LIST 2>/dev/null || true
+_pre_tmp_count=$(compgen -G "/tmp/kubeconfig.*" | wc -l)
+
+use bad-kubeconfig > "$TESTDIR/bad-kube-out" 2>&1
+rc=$?
+if [ $rc -ne 0 ]; then
+    ok "failed op read returns nonzero"
+else
+    fail "failed op read returns nonzero (rc=$rc)"
+fi
+if grep -q "Failed to resolve kubeconfig" "$TESTDIR/bad-kube-out"; then
+    ok "failed op read reports error"
+else
+    fail "failed op read reports error (got: $(cat "$TESTDIR/bad-kube-out"))"
+fi
+if [ -z "${KUBECONFIG:-}" ]; then
+    ok "failed op read does not export KUBECONFIG"
+else
+    fail "failed op read does not export KUBECONFIG (got: ${KUBECONFIG:-})"
+fi
+if [ -z "${AWS_DEFAULT_REGION:-}" ]; then
+    ok "failed use rolls back already-exported vars"
+else
+    fail "failed use rolls back already-exported vars (still: ${AWS_DEFAULT_REGION:-})"
+fi
+if [ -z "${OP_ENV:-}" ] && [ -z "${OP_ENV_LIST:-}" ]; then
+    ok "failed use does not mark env active"
+else
+    fail "failed use does not mark env active (OP_ENV=${OP_ENV:-} OP_ENV_LIST=${OP_ENV_LIST:-})"
+fi
+_post_tmp_count=$(compgen -G "/tmp/kubeconfig.*" | wc -l)
+if [ "$_pre_tmp_count" = "$_post_tmp_count" ]; then
+    ok "failed use leaves no orphan temp kubeconfig"
+else
+    fail "failed use leaves no orphan temp kubeconfig (before=$_pre_tmp_count after=$_post_tmp_count)"
+fi
+
+use bad-token > /dev/null 2>&1
+rc=$?
+if [ $rc -ne 0 ] && [ -z "${KUBECONFIG:-}" ]; then
+    ok "failed token inject returns nonzero without KUBECONFIG"
+else
+    fail "failed token inject returns nonzero without KUBECONFIG (rc=$rc KUBECONFIG=${KUBECONFIG:-unset})"
+fi
+
+# =========================================================================
+#  Tests: use() — values containing '=' are not truncated
+# =========================================================================
+echo ""
+echo "==> Testing use() — values containing '='..."
+
+unset KUBECONFIG OP_ENV OP_ENV_LIST 2>/dev/null || true
+
+use equals-host > /dev/null 2>&1
+if [ -n "${KUBECONFIG:-}" ] && grep -q "scope=admin" "$KUBECONFIG" 2>/dev/null; then
+    ok "host value with '=' written unmodified"
+else
+    fail "host value with '=' written unmodified (KUBECONFIG=${KUBECONFIG:-unset})"
+fi
+unuse equals-host > /dev/null 2>&1
+
+# =========================================================================
+#  Tests: use()/unuse() re-activation is owner-scoped (issue #98)
+# =========================================================================
+# A child shell inherits exported _USE_TMPKUBE_* vars. Re-running use() for
+# the same env, or unuse(), in the child must NOT delete the kubeconfig file
+# a parent/sibling shell created and still points at.
+echo ""
+echo "==> Testing owner-scoped use()/unuse() in child shells (issue #98)..."
+
+unset KUBECONFIG OP_ENV OP_ENV_LIST 2>/dev/null || true
+
+use with-kubeconfig > /dev/null 2>&1
+_parent_kube="$KUBECONFIG"
+
+# Child re-activates the same env (subshell → distinct $BASHPID). It creates
+# its own temp file (removed before exiting); the parent's must survive.
+( use with-kubeconfig > /dev/null 2>&1; rm -f "$KUBECONFIG" )
+if [ -f "$_parent_kube" ]; then
+    ok "child use() preserves parent kubeconfig"
+else
+    fail "child use() preserves parent kubeconfig ($_parent_kube)"
+fi
+
+# Child unuse of the same env must not delete the parent's file either.
+( unuse with-kubeconfig > /dev/null 2>&1 )
+if [ -f "$_parent_kube" ]; then
+    ok "child unuse() preserves parent kubeconfig"
+else
+    fail "child unuse() preserves parent kubeconfig ($_parent_kube)"
+fi
+
+# The owning shell's unuse still deletes its own file.
+unuse with-kubeconfig > /dev/null 2>&1
+if [ ! -f "$_parent_kube" ]; then
+    ok "owner unuse() deletes its own kubeconfig"
+else
+    fail "owner unuse() deletes its own kubeconfig (still exists: $_parent_kube)"
+fi
 
 # =========================================================================
 #  Tests: k8s-unset


### PR DESCRIPTION
## Summary

Three correctness fixes for the `use`/`unuse` environment-switching functions in `dotfiles/.bashrc`, from a review of the kubeconfig resolution path:

- **Fail loudly on kubeconfig resolution errors.** `op read`/`op inject` failures in the `KUBECONFIG_DATA` and `KUBECONFIG_TOKEN`+`KUBECONFIG_HOST` paths were unchecked — a bad ref or expired session silently exported an empty/truncated kubeconfig and still printed "Environment activated". Failures now return nonzero, remove the temp file, and roll back keys already exported (via a new `_use_kube_fail` helper) so a failed `use` doesn't leave a half-active environment.
- **Owner-scope temp-kubeconfig deletion everywhere (extends #98).** The `_USE_TMPKUBE_OWNER_*` check only guarded the EXIT trap. A child shell re-running `use <env>` or `unuse <env>` still deleted the kubeconfig its parent/sibling shell created and pointed at. Both paths now delete the file only when `$BASHPID` matches the recorded owner; `unuse` in a child still unsets its own copies of the vars.
- **Stop truncating values containing `=`.** `KUBECONFIG_*` parsing used `cut -d= -f2`, which dropped everything after a second `=` (e.g. a host URL with a query parameter). Now `cut -d= -f2-`, plus `grep -m1` so a duplicated key can't produce a multi-line ref.

## Testing

- `tests/test-env.sh`: 56 tests passing locally, including new regression tests for all three fixes (failed `op read`/`op inject` handling with rollback and no orphan temp file, `=`-containing values, and child-shell `use`/`unuse` preserving the parent's kubeconfig).
- `shellcheck` on the touched files introduces no new findings.
- Skipped local `make rebuild`/`make test` since this devcontainer session is in use — relying on CI for the full build validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vcrx7ejGov4NorbnXEDi3