### PR TITLE
chore(renovate): exempt digest updates from minimumReleaseAge

### DIFF
--- a/renovate-base.json
+++ b/renovate-base.json
@@ -13,6 +13,13 @@
   "minimumReleaseAge": "10 days",
   "schedule": ["before 11pm on sunday"],
   "separateMajorMinor": false,
+  "packageRules": [
+    {
+      "description": "The age gate is unsatisfiable for digest updates: a floating tag's current digest is always the tip (often <10d old), and action digests resolve without a release timestamp so the stability check pends forever. Let digests ride the weekly schedule; versioned updates keep the 10-day lag.",
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ],
   "customDatasources": {
     "openshift-mirror": {
       "defaultRegistryUrlTemplate": "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.21/release.txt",


### PR DESCRIPTION
## Problem

`minimumReleaseAge: "10 days"` in this shared base blocks **digest** updates permanently, fleet-wide:

- Renovate can only propose a floating tag's **current** digest. For images rebuilt more often than every 10 days (`ghcr.io/ggml-org/llama.cpp:server*` builds several times daily, `itzg/*:latest` roughly weekly), the proposed digest is never old enough — `renovate/stability-days` pends forever, automerge never fires, and each weekly run force-pushes a fresh <10-day digest. A perpetual treadmill.
- GitHub Action digest updates resolve with **no release timestamp**, so the gate fails closed even for old commits — igou-io/igou-openshift#346 proposes a 19-day-old `azure/setup-helm` commit and still pends.

Historically these PRs only ever landed by manual merge past the pending check (e.g. igou-io/igou-openshift#328, #331).

## Change

One `packageRules` entry: `matchUpdateTypes: [digest, pinDigest]` → `minimumReleaseAge: null`.

- Digest updates still batch on the weekly `before 11pm on sunday` schedule.
- All **version** updates (helm charts, tags, releases) keep the 10-day supply-chain lag — the case where the gate actually functions (e.g. igou-openshift#442/#443 pass it correctly today).

## Consumer impact (all repos extending this preset checked)

| Repo | Own rules touching age/digests | Result |
|---|---|---|
| igou-openshift | none on age | digest PRs #434–#439, #346 unblock |
| igou-kubernetes | none on age | unblocks equivalent digest PRs |
| igou-inventory | `digest → automerge: true` | composes; now actually able to fire |
| igou-ansible | already sets `minimumReleaseAge: null` for EE images | consistent precedent; repo rules append after preset, no override conflict |
| igou-containers | no packageRules | inherits cleanly |
| igou-devenv | `pinDigests: false` | few digest updates; no interaction |

Validated with `renovate-config-validator` (renovate 43.260.0): `Config validated successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjuyVWQ2By6b2Ubk2FxBGD