### PR TITLE
feat(ghapp): default GitHub auth to runtime-minted App tokens

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -255,6 +255,28 @@ COPY .devcontainer/requirements.txt /tmp/requirements.txt
 RUN pip install --break-system-packages --ignore-installed -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
 
+# ---------------------------------------------------------------------------
+# ghapp — runtime-minted, repo-scoped GitHub App tokens (credential helper +
+# gh-app/git-app wrappers). Not published to PyPI (the name belongs to
+# upstream), so it installs from a pinned git tag. Renovate bumps GHAPP_VERSION
+# via the `# renovate:` custom manager (github-tags on the plugin repo). Config
+# lives per-user in ~/.config/ghapp/config.yaml (dotfiles/ghapp/config.yaml,
+# seeded by post-create.sh); the App private key is read from 1Password at mint
+# time, never baked here. See README "GitHub Authentication (ghapp)".
+# renovate: datasource=github-tags depName=david-igou/hermes_github_app_plugin
+ARG GHAPP_VERSION="v0.2.0"
+RUN pip install --break-system-packages \
+      "hermes-github-app-plugin @ git+https://github.com/david-igou/hermes_github_app_plugin@${GHAPP_VERSION}"
+
+# Wire the ghapp git credential helper for github.com at the SYSTEM scope: the
+# per-user ~/.gitconfig is bind-mounted read-only from the host, so per-user git
+# config isn't writable in-container. With this, plain HTTPS `git clone/fetch/push`
+# on github.com mints a repo-scoped token via ghapp (useHttpPath gives the helper
+# the OWNER/REPO). URLs that embed x-access-token creds bypass the helper, so this
+# never fights an explicitly-tokenized remote.
+RUN git config --system credential."https://github.com".helper ghapp && \
+    git config --system credential."https://github.com".useHttpPath true
+
 # Configure podman for rootless operation inside a container
 RUN mkdir -p /home/igou/.config/containers
 COPY .devcontainer/containers-storage.conf /home/igou/.config/containers/storage.conf

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -23,6 +23,14 @@ if [ -z "${CI:-}" ]; then
     if [ ! -f /home/igou/.config/code-server/config.yaml ]; then
         cp /workspace/igou-devenv/dotfiles/code-server-config.yaml /home/igou/.config/code-server/config.yaml
     fi
+
+    # GitHub App runtime tokens (ghapp): seed the per-user config. Non-secret
+    # (IDs only); the private key is read from 1Password at mint time. GHAPP_CONFIG
+    # (in .bashrc) points the CLI + git credential helper here.
+    echo "==> Installing ghapp config (GitHub App runtime tokens)..."
+    mkdir -p /home/igou/.config/ghapp
+    cp /workspace/igou-devenv/dotfiles/ghapp/config.yaml /home/igou/.config/ghapp/config.yaml
+    chmod 600 /home/igou/.config/ghapp/config.yaml
 else
     echo "==> CI detected, skipping shell config and workspace file"
 fi

--- a/README.md
+++ b/README.md
@@ -214,6 +214,58 @@ buildah, skopeo) plus `DOCKER_CONFIG` (docker), so container CLIs are
 authenticated for the shell session without `podman login` state on disk.
 See `envs/quay.env` for the shape.
 
+## GitHub Authentication (ghapp)
+
+GitHub auth uses **runtime-minted, repo-scoped GitHub App tokens** (`ghapp`)
+rather than static Personal Access Tokens. Every token is bound to a **single
+repository**, carries only the permissions the operation needs, expires within
+an hour, and is never written to disk — the App private key is read from
+1Password (`op read`) at mint time.
+
+This replaces the old `use claude-david-igou-github-token` / `use
+claude-igou-io-github-token` PAT flow. Those env files still exist but are
+**deprecated** (kept only as a fallback for gaps the App's permission ceiling
+can't cover, e.g. writing Actions secrets).
+
+The App (`igou-dev`) is installed on both accounts; the owner half of
+`OWNER/REPO` picks the installation, so `david-igou/*` and `igou-io/*` both work
+from one config (`~/.config/ghapp/config.yaml`, seeded by `post-create.sh`).
+
+Three ways to authenticate:
+
+```bash
+# 1. Plain git over HTTPS — just works. The ghapp credential helper (baked into
+#    /etc/gitconfig) mints a contents:write token for exactly the repo pushed.
+git clone https://github.com/igou-io/igou-ansible.git
+git -C igou-ansible push
+
+# 2. gh, scoped to one repo — nothing exported into your shell:
+gh-app --repo igou-io/igou-devenv -- pr list
+gh-app --repo david-igou/ansible-collection-devhost --permission contents=read -- release list
+
+# 3. Export a fresh repo-scoped GH_TOKEN into the current shell (for tools that
+#    read GH_TOKEN and can't use gh-app), then clear it:
+ght igou-io/igou-ansible          # default permissions
+ght david-igou/hermes contents=read
+ght-unset
+```
+
+Other entry points from the same identity: `git-app --repo OWNER/REPO -- push
+...` (askpass variant, no helper needed), `ghapp token --repo OWNER/REPO
+[--permission NAME=LEVEL]` (print a raw token), `ghapp api /repos/OWNER/REPO/...`,
+and `ghapp doctor --repo OWNER/REPO` (diagnostics). `--repo` is required
+anywhere a token is minted — tokens are per-repository by design, so there is no
+org-wide token.
+
+> SSH remotes bypass the App identity — use HTTPS remotes for App-authenticated
+> (bot) work. `op` must be authenticated in the shell (it is by default via the
+> bind-mounted `~/.config/op`), since the private key is fetched from 1Password
+> on every mint.
+
+The host side of this (the devenv VM / physical devhost) installs the same
+`ghapp` CLI and credential helper via the `david_igou.devhost.ghapp` role in
+`igou-ansible`'s `playbooks/devenv/bootstrap.yml`.
+
 ## Makefile Targets
 
 | Target | Description |

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -13,6 +13,14 @@ fi
 
 export PATH=$PATH:/home/igou/.local/bin:/home/igou/bin
 
+# GitHub App runtime tokens (ghapp). Point the CLI + git credential helper at the
+# per-user config seeded by post-create.sh. Exported unconditionally (not just for
+# interactive shells) so `git`'s ghapp credential helper finds the config when git
+# is invoked from scripts. The App private key is never on disk here — it is read
+# from 1Password at mint time (config's private_key_cmd), so tokens are repo-scoped
+# and expire within the hour. See README "GitHub Authentication (ghapp)".
+export GHAPP_CONFIG="$HOME/.config/ghapp/config.yaml"
+
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;
@@ -533,6 +541,40 @@ ansible-unset() {
         [[ "$name" == ANSIBLE_* ]] && unset "$name"
     done < <(env)
     echo "Ansible vars unset"
+}
+
+# GitHub App tokens (ghapp) — the default path for GitHub auth, replacing the
+# static-PAT `use claude-*-github-token` flow. Three ways to authenticate:
+#   1. Plain `git` over HTTPS just works — the ghapp credential helper (baked into
+#      /etc/gitconfig) mints a contents:write token for exactly the pushed repo.
+#   2. `gh-app --repo OWNER/REPO -- <args>`  runs `gh` with a repo-scoped token in
+#      GH_TOKEN, nothing exported into your shell.
+#   3. `ght OWNER/REPO [perm=level ...]`  exports a fresh repo-scoped GH_TOKEN into
+#      the CURRENT shell (for tools that read GH_TOKEN and can't use gh-app).
+# App tokens are per-repository by design, so there is no org-wide GH_TOKEN — pass
+# the repo. `ght-unset` clears it. Both orgs (david-igou, igou-io) resolve from the
+# single App config; the owner half of OWNER/REPO selects the installation.
+ght() {
+    if [ -z "${1:-}" ]; then
+        echo "usage: ght OWNER/REPO [perm=level ...]" >&2
+        echo "  e.g. ght igou-io/igou-devenv            (default permissions)" >&2
+        echo "       ght david-igou/hermes contents=read" >&2
+        return 2
+    fi
+    local repo="$1"; shift
+    local perm_args=() p
+    for p in "$@"; do perm_args+=(--permission "$p"); done
+    local tok
+    tok=$(ghapp token --repo "$repo" "${perm_args[@]}") || {
+        echo "ght: failed to mint a token for $repo" >&2
+        return 1
+    }
+    export GH_TOKEN="$tok" GITHUB_TOKEN="$tok" GHT_REPO="$repo"
+    echo "GH_TOKEN minted for $repo (repo-scoped, expires <1h)"
+}
+ght-unset() {
+    unset GH_TOKEN GITHUB_TOKEN GHT_REPO
+    echo "GH_TOKEN cleared"
 }
 
 # Cursor/VS Code shell integration.

--- a/dotfiles/ghapp/config.yaml
+++ b/dotfiles/ghapp/config.yaml
@@ -1,0 +1,26 @@
+---
+# GitHub App identity for runtime-minted, repo-scoped GitHub tokens
+# (david_igou.devhost.ghapp / the `ghapp` CLI). This file is copied to
+# ~/.config/ghapp/config.yaml by .devcontainer/post-create.sh, and the CLI
+# finds it via GHAPP_CONFIG (exported in dotfiles/.bashrc).
+#
+# NONE of these values are secrets: the App client ID, slug, and installation
+# IDs are all safe to commit. The App PRIVATE KEY is deliberately NOT stored
+# here — `private_key_cmd` reads it from 1Password at mint time, so a
+# short-lived (~1h), single-repo token is minted on demand and nothing
+# long-lived ever lands on disk. `op` auth (Connect/service-account) comes from
+# the bind-mounted ~/.config/op, exported by .bashrc.
+#
+# The owner half of OWNER/REPO selects the installation, so one App installed on
+# both accounts needs no per-call plumbing (david-igou repos vs igou-io repos).
+github_app:
+  client_id: "Iv23liP6aQEsyKXnZYiB"
+  app_slug: "igou-dev"
+  installations:
+    david-igou: "143866260"
+    igou-io: "143866153"
+  private_key_cmd: op read "op://claude/igou-dev-github-app/private_key"
+  default_permissions:
+    contents: write
+    pull_requests: write
+    issues: write

--- a/dotfiles/ghapp/config.yaml
+++ b/dotfiles/ghapp/config.yaml
@@ -19,7 +19,7 @@ github_app:
   installations:
     david-igou: "143866260"
     igou-io: "143866153"
-  private_key_cmd: op read "op://claude/igou-dev-github-app/private_key"
+  private_key_cmd: op read "op://lab_external_api_keys/igou-dev-github-app/private_key"
   default_permissions:
     contents: write
     pull_requests: write

--- a/envs/claude-david-igou-github-token.env
+++ b/envs/claude-david-igou-github-token.env
@@ -1,1 +1,8 @@
+# DEPRECATED: static long-lived PAT for the david-igou account. The default GitHub
+# auth path is now ghapp (runtime-minted, repo-scoped, ~1h tokens) — see README
+# "GitHub Authentication (ghapp)": plain HTTPS `git push` works via the credential
+# helper, and `gh-app --repo david-igou/REPO -- <args>` runs gh scoped to one repo.
+# Kept as a fallback for operations the App's permission ceiling can't cover
+# (e.g. writing Actions secrets, which fine-grained/App tokens have failed before).
+# Revoke this PAT once the ghapp flow is proven across all daily david-igou workflows.
 GH_TOKEN=op://claude/claude-david-igou-github-token/password

--- a/envs/claude-igou-io-github-token.env
+++ b/envs/claude-igou-io-github-token.env
@@ -1,1 +1,8 @@
+# DEPRECATED: static long-lived PAT for the igou-io org. The default GitHub auth
+# path is now ghapp (runtime-minted, repo-scoped, ~1h tokens) — see README
+# "GitHub Authentication (ghapp)": plain HTTPS `git push` works via the credential
+# helper, and `gh-app --repo igou-io/REPO -- <args>` runs gh scoped to one repo.
+# Kept as a fallback for operations the App's permission ceiling can't cover
+# (e.g. writing Actions secrets, which fine-grained/App tokens have failed before).
+# Revoke this PAT once the ghapp flow is proven across all daily igou-io workflows.
 GH_TOKEN=op://claude/claude-igou-io-github-token/password

--- a/tests/test-env.sh
+++ b/tests/test-env.sh
@@ -25,6 +25,19 @@ mkdir -p "$TESTDIR/bin"
 cp "$SCRIPT_DIR/mock-op.sh" "$TESTDIR/bin/op"
 export PATH="$TESTDIR/bin:$PATH"
 
+# Mock ghapp binary — ght() calls `ghapp token --repo OWNER/REPO [--permission ...]`.
+# The real ghapp mints via the GitHub App (network + 1Password); the mock just
+# returns a fixed token so we can test the shell plumbing offline.
+cat > "$TESTDIR/bin/ghapp" << 'GHAPP_EOF'
+#!/usr/bin/env bash
+if [ "$1" = "token" ]; then
+    echo "ghs_mockedtoken0123456789"
+    exit 0
+fi
+exit 1
+GHAPP_EOF
+chmod +x "$TESTDIR/bin/ghapp"
+
 # If use() is not already defined (not running inside devcontainer), extract
 # the function definitions from dotfiles/.bashrc and source them.
 if ! type -t use &>/dev/null; then
@@ -823,6 +836,45 @@ if grep -q "op inject" "$MOCK_OP_LOG"; then
     ok "op inject called to resolve secrets"
 else
     fail "op inject called to resolve secrets"
+fi
+
+# =========================================================================
+#  Tests: ght() — GitHub App repo-scoped token export
+# =========================================================================
+echo ""
+echo "==> Testing ght() / ght-unset()..."
+if [ -n "$(type -t ght)" ]; then ok "ght() defined"; else fail "ght() defined"; fi
+if [ -n "$(type -t ght-unset)" ]; then ok "ght-unset() defined"; else fail "ght-unset() defined"; fi
+
+# No-arg usage: returns non-zero and prints usage.
+if type -t ght >/dev/null; then
+    ght_usage=$(ght 2>&1); ght_rc=$?
+    if [ "$ght_rc" -ne 0 ] && echo "$ght_usage" | grep -q "usage: ght"; then
+        ok "ght with no args shows usage and fails"
+    else
+        fail "ght with no args shows usage and fails"
+    fi
+
+    # Mint: exports a repo-scoped GH_TOKEN/GITHUB_TOKEN from the mocked ghapp.
+    unset GH_TOKEN GITHUB_TOKEN GHT_REPO 2>/dev/null || true
+    ght igou-io/igou-devenv > /dev/null 2>&1
+    if [ "${GH_TOKEN:-}" = "ghs_mockedtoken0123456789" ] \
+       && [ "${GITHUB_TOKEN:-}" = "ghs_mockedtoken0123456789" ] \
+       && [ "${GHT_REPO:-}" = "igou-io/igou-devenv" ]; then
+        ok "ght exports repo-scoped GH_TOKEN/GITHUB_TOKEN"
+    else
+        fail "ght exports repo-scoped GH_TOKEN/GITHUB_TOKEN"
+    fi
+
+    # ght-unset clears the exported token.
+    ght-unset > /dev/null 2>&1
+    if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ] && [ -z "${GHT_REPO:-}" ]; then
+        ok "ght-unset clears GH_TOKEN"
+    else
+        fail "ght-unset clears GH_TOKEN"
+    fi
+else
+    fail "ght() available for token tests"
 fi
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Migrates the devcontainer's daily GitHub auth from **static long-lived PATs** to
**runtime-minted, repo-scoped GitHub App tokens** (`ghapp`). Every token is bound
to a single repository, carries only the permissions the operation needs, expires
within an hour, and is never written to disk — the App private key is read from
1Password (`op read`) at mint time.

Pairs with igou-io/igou-ansible#375 (the host side installs the same
plugin via `david_igou.devhost.ghapp`) and the new `v0.2.0` tag on
david-igou/hermes_github_app_plugin.

## What changed

- **Dockerfile**: install the `hermes-github-app-plugin` CLI from a pinned git tag
  (`ARG GHAPP_VERSION="v0.2.0"`, Renovate-bumpable via the existing `# renovate:`
  github-tags custom manager), and wire the ghapp git credential helper for
  github.com at the **system** scope (`/etc/gitconfig`) — the per-user
  `~/.gitconfig` is bind-mounted read-only, so system scope is the only writable
  place. URLs that embed `x-access-token` creds bypass the helper, so it never
  fights an explicitly-tokenized remote.
- **dotfiles/ghapp/config.yaml**: per-user App config (non-secret IDs only). The
  key comes from `private_key_cmd: op read "op://claude/igou-dev-github-app/private_key"`
  — never stored. Seeded to `~/.config/ghapp/config.yaml` by `post-create.sh`.
- **dotfiles/.bashrc**: export `GHAPP_CONFIG`; add `ght OWNER/REPO [perm=level ...]`
  / `ght-unset` helpers that export a fresh repo-scoped `GH_TOKEN` for tools that
  read it directly.
- **envs/claude-*-github-token.env**: static PATs marked **DEPRECATED** (kept as a
  fallback for gaps the App's permission ceiling can't cover — e.g. Actions-secrets
  writes, which fine-grained/App tokens have failed before).
- **README**: new "GitHub Authentication (ghapp)" section.
- **tests/test-env.sh**: cover `ght()`/`ght-unset()` with a mocked `ghapp`.

## UX decisions

App tokens are **per-repository by design**, so there is no org-wide `GH_TOKEN` to
export — the old `use claude-igou-io-github-token` mental model doesn't map. The
cleanest replacement, documented in the README, is three entry points from one
identity (both `david-igou/*` and `igou-io/*` resolve from a single config; the
owner half of `OWNER/REPO` picks the installation):

1. **plain HTTPS `git`** — just works via the credential helper (zero friction).
2. **`gh-app --repo OWNER/REPO -- <args>`** — runs `gh` with a repo-scoped token,
   nothing exported into the shell.
3. **`ght OWNER/REPO`** — exports a fresh repo-scoped `GH_TOKEN` into the current
   shell for tools that can't use `gh-app`; `ght-unset` clears it.

## Pinning / Renovate

The plugin is not on PyPI (the name belongs to upstream), so it installs from a git
tag. `ARG GHAPP_VERSION` is matched by the repo's existing `# renovate:` custom
manager (`datasource=github-tags`), so Renovate opens a bump PR when a newer tag is
cut — same pattern as the other pinned CLI tools. The `v0.2.0` tag was cut on the
plugin repo as part of this work (was previously installed off `@main`).

## Sequencing note (why verification used a manual in-container install)

The live VLAN9 VM is pinned to image `2026.07.12`, which predates these changes, so
the container-layer bits ship with the **next weekly release** (or a manual
release-cut). For live verification now, the plugin was installed manually inside
the running code-server container and the flow proven end to end (below). The
durable path is this PR + the release that bakes it into the image.

## Live verification (in-container, both orgs)

Manually installed `v0.2.0` into the running `igou-devenv-code-server` container,
wrote the per-user config with the `op read` key command, set the system credential
helper, and (injecting Connect creds to stand in for the bind-mounted `~/.config/op`
the real devcontainer provides) exercised both orgs with **no `GH_TOKEN` in env**:

```
op read op://claude/igou-dev-github-app/private_key         → PEM fetched in-container
ghapp doctor --repo igou-io/igou-devenv                     → Doctor passed  (key source: cmd: op read ...)
ghapp doctor --repo david-igou/hermes_github_app_plugin     → Doctor passed
gh-app --repo igou-io/igou-devenv -- api repos/...          → igou-io/igou-devenv
gh-app --repo david-igou/hermes_github_app_plugin -- api .. → david-igou/hermes_github_app_plugin
git ls-remote https://github.com/igou-io/igou-devenv.git    → 2ca284e   (credential helper)
git ls-remote https://github.com/david-igou/hermes_..._plugin → 4fe6f08 (credential helper)
```

`tests/test-env.sh`: 82 passed, 0 failed (includes the 5 new `ght` tests).
Shellcheck clean on the `.bashrc` / `post-create.sh` additions.

## Operator follow-ups

- **Release-cut** needed to get these image changes onto the pinned VLAN9 VM (and
  the physical rebuild): promote a new `igou-devenv` release and bump
  `devenv_image`/`devenv_repo_version` in `igou-ansible`'s `bootstrap.yml`.
- **PAT deprecation/revocation**: the two `claude-*-github-token` items in vault
  `claude` can be revoked once the ghapp flow is proven across all daily workflows
  for that account/org — keep them until any App permission-ceiling gaps (e.g.
  Actions-secrets writes) are resolved or explicitly accepted.
- The App's installation permission ceiling is fixed at the GitHub App settings
  level; if a workflow needs a permission the App lacks, raise it there (or fall
  back to the PAT).

---

## Update — repoint ghapp key to lab_external_api_keys (stacked commit)

The `igou-dev-github-app` 1Password item was moved out of the `claude` vault into **`lab_external_api_keys`** (byte-identical copy of all 5 fields verified, incl. the 27-line PEM). `dotfiles/ghapp/config.yaml`'s in-container `private_key_cmd` now reads:

```
op read "op://lab_external_api_keys/igou-dev-github-app/private_key"
```

Companion PRs: igou-ansible#375 (host-side ghapp now sourced from inventory group_vars) and igou-inventory#160 (the `devenv` group + `group_vars/devenv/ghapp.yml`).

**Note on the live container:** the running code-server container is on the published `2026.07.12` image, whose baked dotfiles still reference `op://claude`. The in-container path only picks up this change after a new image is built and deployed. Until then the **old `claude`-vault item must stay** — deleting it now would break the running container's in-container `op read`. Operator cleanup: delete/archive the `claude` copy once a new image ships and the live container is redeployed onto it. (The host-side ghapp is unaffected — it uses a key.pem written from the inventory lookup, already on `lab_external_api_keys`.)

bwrap 0.10.0 is already present in the image — no Dockerfile change needed for bubblewrap. The container-runtime flag that makes it work (`seccomp=unconfined`) lives in igou-ansible#375's container launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Lq5KqQ3Wj6C3M7B92NVih

