### PR TITLE
chore: remove legacy 1Password SSH agent-forwarding workarounds

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -12,8 +12,7 @@ fi
 # No host agent forwarding: a dedicated agent listens on the fixed socket
 # path devcontainer.json exports as SSH_AUTH_SOCK. It starts empty — load
 # keys on demand from 1Password with ssh-use (dotfiles/.bashrc).
-# Non-fatal: a container created before adr/0004 still has the host socket
-# bind-mounted at this path, and the rest of post-start must still run.
+# Non-fatal: agent bootstrap must not block the rest of post-start.
 # ---------------------------------------------------------------------------
 echo "==> Ensuring container-local SSH agent..."
 /workspace/igou-devenv/bin/ensure-ssh-agent 2>&1 | sed 's/^/    /' \

--- a/README.md
+++ b/README.md
@@ -596,8 +596,6 @@ ssh-use             # (re)load the key — it may have hit its TTL
 ```bash
 ensure-ssh-agent    # restart the container-local agent, then ssh-use again
 ```
-A container created before ADR-0004 may still have the old host socket
-bind-mounted at `/tmp/ssh-agent.sock`; recreate it with `make down && make up`.
 
 **`ssh-use` fails to resolve the key:** check 1Password auth (`op vault list`)
 and that the item exists: `op read "op://lab_ssh/github/public key"`.

--- a/bin/ensure-ssh-agent
+++ b/bin/ensure-ssh-agent
@@ -21,10 +21,6 @@ rm -f "$SOCK" 2>/dev/null || true
 if ssh-agent -a "$SOCK" >/dev/null 2>&1; then
     echo "Started ssh-agent on ${SOCK}"
 else
-    # Most likely a container created before adr/0004: the host agent socket
-    # is still bind-mounted at this path and a mountpoint can't be replaced
-    # from inside the container.
-    echo "WARNING: could not start ssh-agent on ${SOCK}"
-    echo "If this container predates adr/0004, recreate it: make down && make up"
+    echo "ERROR: could not start ssh-agent on ${SOCK}"
     exit 1
 fi

--- a/doc/prerequisites.md
+++ b/doc/prerequisites.md
@@ -82,58 +82,24 @@ launchers run podman inside the devcontainer).
 
 ## SSH
 
-- **SSH key pair** registered with GitHub (ed25519 or RSA).
-- **SSH agent** running on the host with the key loaded (`ssh-add`).
-- The Makefile dynamically bind-mounts `$SSH_AUTH_SOCK` into the container. If the socket does not exist, the mount is skipped gracefully.
+SSH keys are **not** kept on the host or forwarded into the container. The
+devcontainer runs its own ssh-agent (started empty by `bin/ensure-ssh-agent`)
+and keys are pulled from 1Password on demand with `ssh-use` — see
+[adr/0004](../adr/0004-ssh-keys-from-1password.md).
 
-### Playbook: SSH key and agent setup
+The host only needs:
 
-```yaml
----
-- name: SSH key and agent setup
-  hosts: localhost
-  connection: local
-  vars:
-    ssh_key_path: "{{ ansible_env.HOME }}/.ssh/id_ed25519"
-    ssh_key_comment: "{{ ansible_user_id }}@{{ ansible_hostname }}"
-  tasks:
-    - name: Ensure ~/.ssh directory exists
-      ansible.builtin.file:
-        path: "{{ ansible_env.HOME }}/.ssh"
-        state: directory
-        mode: "0700"
+- `~/.ssh/config` and `~/.ssh/known_hosts` — bind-mounted read-only into the
+  container. No private key on disk, no host ssh-agent, no agent forwarding.
+- Your SSH keys stored in the 1Password `lab_ssh` vault, resolved in-container
+  via the 1Password CLI (see the [1Password CLI](#1password-cli) section below).
 
-    - name: Generate ed25519 SSH key pair
-      community.crypto.openssh_keypair:
-        path: "{{ ssh_key_path }}"
-        type: ed25519
-        comment: "{{ ssh_key_comment }}"
-      register: ssh_key
+Inside the container:
 
-    - name: Ensure SSH agent is running
-      ansible.builtin.shell: |
-        eval "$(ssh-agent -s)"
-        echo "$SSH_AUTH_SOCK"
-      args:
-        executable: /bin/bash
-      environment:
-        SSH_AUTH_SOCK: "{{ ansible_env.SSH_AUTH_SOCK | default('') }}"
-      register: ssh_agent
-      changed_when: false
-      when: ansible_env.SSH_AUTH_SOCK is not defined or ansible_env.SSH_AUTH_SOCK == ""
-
-    - name: Add key to SSH agent
-      ansible.builtin.shell: ssh-add {{ ssh_key_path }}
-      args:
-        executable: /bin/bash
-      changed_when: false
-
-    - name: Show public key for GitHub registration
-      ansible.builtin.debug:
-        msg: >-
-          Add this public key to GitHub (Settings → SSH and GPG keys):
-          {{ lookup('file', ssh_key_path + '.pub') }}
-      when: ssh_key.changed
+```bash
+ssh-use            # load the default key (op://lab_ssh/github)
+ssh-use lab-nodes  # load a specific key
+ssh-unuse          # drop all loaded keys
 ```
 
 ## 1Password CLI


### PR DESCRIPTION
## Summary

Host SSH-agent forwarding was replaced by a container-local agent that loads keys from 1Password on demand (`ssh-use`/`ssh-unuse`) in [adr/0004](../blob/main/adr/0004-ssh-keys-from-1password.md). The forwarding machinery itself (`_fix_ssh_auth_sock`, `find_working_ssh_sock`, the Makefile `SSH_MOUNT` bind-mount) was already deleted then — but **relics of that era lingered in scripts and docs**. With the 1Password client SSH agent now being removed from workstations entirely, this drops the leftovers.

## Changes

- **`bin/ensure-ssh-agent`** — remove the pre-adr/0004 "host socket bind-mounted at this path / `make down && make up`" fallback branch. The generic stale-socket replacement (leftover socket from a crashed prior container-local agent) is **kept**.
- **`.devcontainer/post-start.sh`** — drop the comment about legacy containers still carrying the host socket bind-mount; keep the bootstrap non-fatal.
- **`README.md`** — remove the pre-adr/0004 host-socket troubleshooting note.
- **`doc/prerequisites.md`** — rewrite the stale SSH section that still told users to run a host ssh-agent, generate an on-disk key, and rely on a Makefile bind-mount of `$SSH_AUTH_SOCK`; document the `ssh-use`/1Password model instead.

## Deliberately untouched

- **`bin/ensure-ssh-agent` is kept** — it is *not* a forwarding workaround. It is the successor that starts the empty container-local agent `ssh-use` loads keys into via `ssh-add`. Removing it would break `ssh-use`.
- **`adr/0004-ssh-keys-from-1password.md`** — immutable historical record; its "what we removed" prose stays.
- **`ssh-use`/`ssh-unuse` helpers + their tests** — the successors, retained.

## Test impact

`tests/test-ssh.sh` only asserts on `"Started ssh-agent"` / `"Reusing ssh-agent"` (both preserved) and the stale-socket replacement behavior (kept). No test references the removed legacy strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)